### PR TITLE
Add run details

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -11,6 +11,12 @@ PARAM_VARS_MANDATORY=(
   'RUN_NAMESPACE'
 )
 
+PARAM_VARS_OPTIONAL=(
+  'JOB_NAME'
+  'RUN_NUMBER'
+  'RUN_CAUSE'
+)
+
 _JENKINS_APP_DIR="/app/jenkins"
 _JENKINS_CASC_D="${_JENKINS_APP_DIR}/WEB-INF/jenkins.yaml.d"
 _JENKINS_HOME="/jenkins_home"
@@ -133,6 +139,9 @@ jfr_cmd=(
     -p /usr/share/jenkins/ref/plugins
     --runHome "${_JENKINS_HOME}"
     --no-sandbox
+    ${JOB_NAME:+"--job-name=${JOB_NAME}"}
+    ${RUN_NUMBER:+"--build-number=${RUN_NUMBER}"}
+    ${RUN_CAUSE:+"--cause=${RUN_CAUSE}"}
     -f "$PIPELINE_FILE"
     "${JFR_PIPELINE_PARAM_ARGS[@]}"
 )


### PR DESCRIPTION
Allow the definition of environment variables
JOB_NAME, RUN_NUMBER and RUN_CAUSE
and pass the values to jenkinsfile runner as
--job-name, --build-number and --cause if set.

Requires
jenkinsci/jenkinsfile-runner@bbb316c7b7e9d2902a6ac667626afbc324f12e3f