### PR TITLE
Fix usage in Kubernetes via Tekton

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ docker run \
   -e PIPELINE_FILE=success/Jenkinsfile \
   -e PIPELINE_PARAMS_JSON={} \
   -e RUN_NAMESPACE=anything \
-  stewardci/stewardci-jenkinsfile-runner
+  -v "/workspace" \
+  -w "/workspace" \
+  stewardci/stewardci-jenkinsfile-runner:191031_07973f6
 ```
 
 To build and test from sources execute the following commands:
@@ -34,6 +36,8 @@ docker run \
   -e PIPELINE_FILE=success/Jenkinsfile \
   -e PIPELINE_PARAMS_JSON={} \
   -e RUN_NAMESPACE=anything \
+  -v "/workspace" \
+  -w "/workspace" \
   stewardci-jenkinsfile-runner-local
 ```
 

--- a/jenkinsfile-runner-steward-image/scripts/run.sh
+++ b/jenkinsfile-runner-steward-image/scripts/run.sh
@@ -132,8 +132,6 @@ build_xml="${_JENKINS_HOME}/jobs/job/builds/1/build.xml"
 truncate --no-create --size 0 /dev/termination-log || exit 1
 check_required_env_vars "${PARAM_VARS_MANDATORY[@]}" || exit 1
 
-mkdir /workspace || exit 1
-cd /workspace || exit 1
 echo "Cloning pipeline repository $PIPELINE_GIT_URL"
 with_termination_log git clone "$PIPELINE_GIT_URL" . || exit 1
 echo "Checking out pipeline from revision $PIPELINE_GIT_REVISION"


### PR DESCRIPTION
Tekton mounts the /workspace folder. `mkdir` fails in this case. For the docker example in the README we should also mount the /workspace folder.