### PR TITLE
Improve plugin-printer script so it works in ppiper/jenkinsfile-runner

### DIFF
--- a/jenkinsfile-runner-base-image/README.md
+++ b/jenkinsfile-runner-base-image/README.md
@@ -13,6 +13,8 @@ Below you find ways to generate this list.
 From the Script Console of a running Jenkins execute the following script to get the list of all installed plugins, preformatted for the `packager-config.yml`.
 
 ```groovy
+import com.cloudbees.groovy.cps.NonCPS
+
 printPlugins(Jenkins.instance.pluginManager.plugins)
 true
 

--- a/jenkinsfile-runner-base-image/README.md
+++ b/jenkinsfile-runner-base-image/README.md
@@ -13,24 +13,38 @@ Below you find ways to generate this list.
 From the Script Console of a running Jenkins execute the following script to get the list of all installed plugins, preformatted for the `packager-config.yml`.
 
 ```groovy
-def JENKINS_HOME = System.getenv('JENKINS_HOME')
+printPlugins(Jenkins.instance.pluginManager.plugins)
+true
 
-Jenkins.instance.pluginManager.plugins.toSorted {
-  a, b -> a.shortName <=> b.shortName
-}
-.each {
-  plugin ->
-  def groupId
-  def manifestFile = new File(JENKINS_HOME, "plugins/${plugin.shortName}/META-INF/MANIFEST.MF")
-  manifestFile.withInputStream { mfStream ->
-    def manifest = new java.util.jar.Manifest(mfStream)
-    groupId = manifest.mainAttributes.getValue("Group-Id")
-  }
-  println("""\
+@NonCPS
+def printPlugins(plugins) {
+    def JENKINS_HOME = System.getenv('JENKINS_HOME')
+
+    def pluginsDir
+
+    if (new File("${JENKINS_HOME}/plugins").exists()) {
+        pluginsDir = "${JENKINS_HOME}/plugins"
+    } else if (new File("/usr/share/jenkins/ref/plugins").exists()) {
+        pluginsDir = "/usr/share/jenkins/ref/plugins"
+    } else {
+        throw new RuntimeException("Could not determine plugins directory.")
+    }
+
+    plugins.toSorted {
+        a, b -> a.shortName <=> b.shortName
+    }.each {
+        plugin ->
+            def groupId
+            def manifestFile = new File("${pluginsDir}/${plugin.shortName}/META-INF/MANIFEST.MF")
+            manifestFile.withInputStream { mfStream ->
+                def manifest = new java.util.jar.Manifest(mfStream)
+                groupId = manifest.mainAttributes.getValue("Group-Id")
+            }
+            println("""\
   - groupId: "${groupId}"
     artifactId: "${plugin.shortName}"
     source:
       version: "${plugin.version}\"""")
+    }
 }
-true
 ```


### PR DESCRIPTION
This moves the code into a NonCPS method to avoid exceptions in Jenkinsfile Runner (in toSorted), and has some primitive plugin dir discovery. Tested in ppiper/jenkinsfile-runner and in an instance based on ppiper/jenkins-master.