### PR TITLE
Do not run as root

### DIFF
--- a/jenkinsfile-runner-steward-image/Dockerfile
+++ b/jenkinsfile-runner-steward-image/Dockerfile
@@ -1,7 +1,18 @@
-FROM jenkinsfile-runner-base-local
+FROM jenkinsfile-runner-base-local as packager-output
+FROM openjdk:8-alpine
 
-RUN apk add jq python3 xmlstarlet
+RUN apk add jq python3 xmlstarlet bash git
+RUN addgroup -g 1000 jenkins && adduser -D -u 1000 -G jenkins jenkins
+RUN mkdir -p /run && chmod o+w /run
+RUN mkdir /jenkins_home && chown jenkins:jenkins /jenkins_home
+USER jenkins:jenkins
+
+COPY --from=packager-output --chown=jenkins:jenkins /app /app
+COPY --from=packager-output --chown=jenkins:jenkins /usr/share/jenkins /usr/share/jenkins
+
+# we want to clone the pipeline directory here:
+RUN mkdir /tmp/pipeline
+WORKDIR /tmp/pipeline
 
 COPY scripts/ /scripts
-
 ENTRYPOINT [ "bash", "/scripts/run.sh" ]

--- a/jenkinsfile-runner-steward-image/Dockerfile
+++ b/jenkinsfile-runner-steward-image/Dockerfile
@@ -5,14 +5,18 @@ RUN apk add jq python3 xmlstarlet bash git
 RUN addgroup -g 1000 jenkins && adduser -D -u 1000 -G jenkins jenkins
 RUN mkdir -p /run && chmod o+w /run
 RUN mkdir /jenkins_home && chown jenkins:jenkins /jenkins_home
+# we want to clone the pipeline directory here:
+RUN mkdir -p /workspace && chown jenkins:jenkins /workspace
+
+VOLUME /jenkins_home
+VOLUME /workspace
+WORKDIR /workspace
+
 USER jenkins:jenkins
 
 COPY --from=packager-output --chown=jenkins:jenkins /app /app
 COPY --from=packager-output --chown=jenkins:jenkins /usr/share/jenkins /usr/share/jenkins
 
-# we want to clone the pipeline directory here:
-RUN mkdir /tmp/pipeline
-WORKDIR /tmp/pipeline
 
 COPY scripts/ /scripts
 ENTRYPOINT [ "bash", "/scripts/run.sh" ]


### PR DESCRIPTION
We copy the relevant files from the image created by the customer war packager.
That way, we can avoid creating new layers by modifying meta data.