### PR TITLE
Rollback termination log location to old state

### DIFF
--- a/jenkinsfile-runner-steward-image/scripts/run.sh
+++ b/jenkinsfile-runner-steward-image/scripts/run.sh
@@ -25,7 +25,11 @@ _JENKINS_APP_DIR="/app/jenkins"
 _JENKINS_CASC_D="${_JENKINS_APP_DIR}/WEB-INF/jenkins.yaml.d"
 _JENKINS_HOME="/jenkins_home"
 
+# This is only usable with tekton 0.11.x if running in non root mode.
+# See https://github.com/tektoncd/pipeline/issues/2131
 _TERMINATION_LOG_PATH="/tekton/results/termination-log"
+
+_TERMINATION_LOG_PATH="/run/termination-log"
 
 function check_required_env_vars() {
   local rc=0 var

--- a/jenkinsfile-runner-steward-image/scripts/run.sh
+++ b/jenkinsfile-runner-steward-image/scripts/run.sh
@@ -27,7 +27,7 @@ _JENKINS_HOME="/jenkins_home"
 
 # This is only usable with tekton 0.11.x if running in non root mode.
 # See https://github.com/tektoncd/pipeline/issues/2131
-_TERMINATION_LOG_PATH="/tekton/results/termination-log"
+#_TERMINATION_LOG_PATH="/tekton/results/termination-log"
 
 _TERMINATION_LOG_PATH="/run/termination-log"
 


### PR DESCRIPTION
The change is only working with tekton 0.11.x

See https://github.com/tektoncd/pipeline/issues/2131