### PR TITLE
Delete ~/.git-credentials after pipeline clone

### DIFF
--- a/jenkinsfile-runner-steward-image/scripts/run.sh
+++ b/jenkinsfile-runner-steward-image/scripts/run.sh
@@ -143,7 +143,7 @@ with_termination_log git clone "$PIPELINE_GIT_URL" . || exit 1
 echo "Checking out pipeline from revision $PIPELINE_GIT_REVISION"
 with_termination_log git checkout "$PIPELINE_GIT_REVISION" || exit 1
 echo "Delete pipeline git clone credentials"
-with_termination_log rm "~/.git-credentials" || exit 1
+with_termination_log rm -f ~/.git-credentials || exit 1
 
 with_termination_log sed -i "s/0.0.0.0/$(hostname -i)/g" "$casc_yml" || exit 1
 with_termination_log sed -i "s/xxx/$RUN_NAMESPACE/" "$casc_yml" || exit 1

--- a/jenkinsfile-runner-steward-image/scripts/run.sh
+++ b/jenkinsfile-runner-steward-image/scripts/run.sh
@@ -142,6 +142,8 @@ echo "Cloning pipeline repository $PIPELINE_GIT_URL"
 with_termination_log git clone "$PIPELINE_GIT_URL" . || exit 1
 echo "Checking out pipeline from revision $PIPELINE_GIT_REVISION"
 with_termination_log git checkout "$PIPELINE_GIT_REVISION" || exit 1
+echo "Delete pipeline git clone credentials"
+with_termination_log rm "~/.git-credentials" || exit 1
 
 with_termination_log sed -i "s/0.0.0.0/$(hostname -i)/g" "$casc_yml" || exit 1
 with_termination_log sed -i "s/xxx/$RUN_NAMESPACE/" "$casc_yml" || exit 1


### PR DESCRIPTION
The git credentials interfere with git credentials used inside the pipeline.