### PR TITLE
Consume elasticsearch-log-plugin:v0.2.0

### DIFF
--- a/jenkinsfile-runner-base-image/packager-config.yml
+++ b/jenkinsfile-runner-base-image/packager-config.yml
@@ -52,7 +52,7 @@ plugins:
     artifactId: "pipeline-elasticsearch-logs"
     source:
       git: "https://github.com/SAP/elasticsearch-logs-plugin.git"
-      commit: "0.0.1"
+      commit: "v0.2.0"
 
 
 # See plugins.txt for plugin selection without dependencies (keep this list in sync)

--- a/jenkinsfile-runner-steward-image/scripts/create_elasticsearch_log_config.py
+++ b/jenkinsfile-runner-steward-image/scripts/create_elasticsearch_log_config.py
@@ -28,6 +28,7 @@ if url:
                 "elasticSearch": {
                     "certificateId": certificateId if certificateId else None,
                     "credentialsId": credentialsId if credentialsId else None,
+                    "elasticsearchWriteAccess": "esDirectWrite",
                     "runIdProvider": {
                         "json": {
                             "jsonSource": {


### PR DESCRIPTION
This version reads the logs from the local filesystem instead of Elasticsearch.
