### PR TITLE
Define admin email address in global configuration

### DIFF
--- a/jenkinsfile-runner-base-image/casc.yml
+++ b/jenkinsfile-runner-base-image/casc.yml
@@ -9,3 +9,6 @@ jenkins:
       name: "kubernetes"
       namespace: "xxx"
       serverUrl: "https://kubernetes.default"
+unclassified:
+  location:
+    adminAddress: "noreply@sap.com"


### PR DESCRIPTION
Otherwise it might happen cluster/pod internals are used to generate an email address. Internas should not be exposed.