### PR TITLE
Update jdk8 to adoptjdk11, Jenkins core and some plugins

### DIFF
--- a/jenkinsfile-runner-base-image/packager-config.yml
+++ b/jenkinsfile-runner-base-image/packager-config.yml
@@ -18,7 +18,7 @@ buildSettings:
         git: https://github.com/jenkinsci/jenkinsfile-runner.git
         branch: "1.0-beta-12"
     docker:
-      base: "jenkins/jenkins:2.235.4-alpine"
+      base: "jenkins/jenkins:2.249.1-alpine"
       tag: "jenkinsfile-runner-base-local"
       build: true
 
@@ -26,7 +26,7 @@ war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.235.4"
+    version: "2.249"
 
 systemProperties:
     jenkins.model.Jenkins.slaveAgentPort: "50000"
@@ -74,11 +74,11 @@ plugins:
     artifactId: "analysis-core"
     source:
       version: "1.96"
-# Analysis Model API (Jenkins-Version: 2.204.4)
+# Analysis Model API (Jenkins-Version: 2.204.6)
   - groupId: "io.jenkins.plugins"
     artifactId: "analysis-model-api"
     source:
-      version: "8.2.1"
+      version: "9.0.1"
 # OWASP Markup Formatter (Jenkins-Version: 2.121.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "antisamy-markup-formatter"
@@ -99,11 +99,11 @@ plugins:
     artifactId: "badge"
     source:
       version: "1.8"
-# Bootstrap 4 API (Jenkins-Version: 2.204.4)
+# Bootstrap 4 API (Jenkins-Version: 2.204.6)
   - groupId: "io.jenkins.plugins"
     artifactId: "bootstrap4-api"
     source:
-      version: "4.5.0-2"
+      version: "4.5.2-1"
 # bouncycastle API (Jenkins-Version: 2.60.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "bouncycastle-api"
@@ -113,17 +113,17 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "branch-api"
     source:
-      version: "2.5.9"
+      version: "2.6.0"
 # Build Timeout (Jenkins-Version: 2.222.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "build-timeout"
     source:
       version: "1.20"
-# Checks API (Jenkins-Version: 2.204.4)
+# Checks API (Jenkins-Version: 2.204.6)
   - groupId: "io.jenkins.plugins"
     artifactId: "checks-api"
     source:
-      version: "0.2.3"
+      version: "1.0.0"
 # Folders (Jenkins-Version: 2.176.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "cloudbees-folder"
@@ -153,7 +153,7 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "credentials"
     source:
-      version: "2.3.12"
+      version: "2.3.13"
 # Credentials Binding (Jenkins-Version: 2.164.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "credentials-binding"
@@ -178,22 +178,22 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "durable-task"
     source:
-      version: "1.34"
-# ECharts API (Jenkins-Version: 2.204.4)
+      version: "1.35"
+# ECharts API (Jenkins-Version: 2.204.6)
   - groupId: "io.jenkins.plugins"
     artifactId: "echarts-api"
     source:
-      version: "4.8.0-2"
+      version: "4.9.0-1"
 # Email Extension (Jenkins-Version: 2.164.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "email-ext"
     source:
-      version: "2.74"
-# Font Awesome API (Jenkins-Version: 2.138.4)
+      version: "2.77"
+# Font Awesome API (Jenkins-Version: 2.204.4)
   - groupId: "io.jenkins.plugins"
     artifactId: "font-awesome-api"
     source:
-      version: "5.13.0-1"
+      version: "5.14.0-1"
 # Forensics API (Jenkins-Version: 2.138.4)
   - groupId: "io.jenkins.plugins"
     artifactId: "forensics-api"
@@ -208,12 +208,12 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "git"
     source:
-      version: "4.3.0"
+      version: "4.4.4"
 # Git client (Jenkins-Version: 2.204.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "git-client"
     source:
-      version: "3.3.2"
+      version: "3.5.1"
 # GIT server (Jenkins-Version: 2.138.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "git-server"
@@ -228,12 +228,12 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "github-api"
     source:
-      version: "1.115"
-# GitHub Branch Source (Jenkins-Version: 2.164.3)
+      version: "1.116"
+# GitHub Branch Source (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "github-branch-source"
     source:
-      version: "2.8.3"
+      version: "2.9.0"
 # Gradle (Jenkins-Version: 2.138.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "gradle"
@@ -268,7 +268,7 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "jacoco"
     source:
-      version: "3.0.7"
+      version: "3.0.8"
 # Javadoc (Jenkins-Version: 2.60.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "javadoc"
@@ -289,21 +289,21 @@ plugins:
     artifactId: "jsch"
     source:
       version: "0.1.55.2"
-# JUnit (Jenkins-Version: 2.204.4)
+# JUnit (Jenkins-Version: 2.204.6)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "junit"
     source:
-      version: "1.31"
+      version: "1.37"
 # Kubernetes (Jenkins-Version: 2.222.4)
   - groupId: "org.csanchez.jenkins.plugins"
     artifactId: "kubernetes"
     source:
-      version: "1.26.4"
+      version: "1.27.0"
 # Kubernetes Client API (Jenkins-Version: 2.204.6)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "kubernetes-client-api"
     source:
-      version: "4.9.2-2"
+      version: "4.11.1"
 # Kubernetes Credentials (Jenkins-Version: 2.204.6)
   - groupId: "org.jenkinsci.plugins"
     artifactId: "kubernetes-credentials"
@@ -318,12 +318,12 @@ plugins:
   - groupId: "org.6wind.jenkins"
     artifactId: "lockable-resources"
     source:
-      version: "2.8"
+      version: "2.10"
 # Mailer (Jenkins-Version: 2.150.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "mailer"
     source:
-      version: "1.32"
+      version: "1.32.1"
 # Matrix Project (Jenkins-Version: 2.164.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "matrix-project"
@@ -364,11 +364,11 @@ plugins:
     artifactId: "pipeline-graph-analysis"
     source:
       version: "1.10"
-# Pipeline: Input Step (Jenkins-Version: 2.138.4)
+# Pipeline: Input Step (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "pipeline-input-step"
     source:
-      version: "2.11"
+      version: "2.12"
 # Pipeline: Milestone Step (Jenkins-Version: 1.642.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "pipeline-milestone-step"
@@ -378,22 +378,22 @@ plugins:
   - groupId: "org.jenkinsci.plugins"
     artifactId: "pipeline-model-api"
     source:
-      version: "1.7.1"
+      version: "1.7.2"
 # Pipeline: Declarative (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkinsci.plugins"
     artifactId: "pipeline-model-definition"
     source:
-      version: "1.7.1"
+      version: "1.7.2"
 # Pipeline: Declarative Extension Points API (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkinsci.plugins"
     artifactId: "pipeline-model-extensions"
     source:
-      version: "1.7.1"
+      version: "1.7.2"
 # Pipeline: REST API (Jenkins-Version: 2.60.3)
   - groupId: "org.jenkins-ci.plugins.pipeline-stage-view"
     artifactId: "pipeline-rest-api"
     source:
-      version: "2.14"
+      version: "2.15"
 # Pipeline: Stage Step (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "pipeline-stage-step"
@@ -403,12 +403,12 @@ plugins:
   - groupId: "org.jenkinsci.plugins"
     artifactId: "pipeline-stage-tags-metadata"
     source:
-      version: "1.7.1"
+      version: "1.7.2"
 # Pipeline: Stage View (Jenkins-Version: 2.60.3)
   - groupId: "org.jenkins-ci.plugins.pipeline-stage-view"
     artifactId: "pipeline-stage-view"
     source:
-      version: "2.14"
+      version: "2.15"
 # Pipeline Utility Steps (Jenkins-Version: 2.121.2)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "pipeline-utility-steps"
@@ -419,11 +419,11 @@ plugins:
     artifactId: "plain-credentials"
     source:
       version: "1.7"
-# Plugin Utilities API (Jenkins-Version: 2.204.4)
+# Plugin Utilities API (Jenkins-Version: 2.204.6)
   - groupId: "io.jenkins.plugins"
     artifactId: "plugin-util-api"
     source:
-      version: "1.2.2"
+      version: "1.2.5"
 # Popper.js API (Jenkins-Version: 2.138.4)
   - groupId: "io.jenkins.plugins"
     artifactId: "popper-api"
@@ -434,21 +434,21 @@ plugins:
     artifactId: "resource-disposer"
     source:
       version: "0.14"
-# SCM API (Jenkins-Version: 2.107.3)
+# SCM API (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "scm-api"
     source:
-      version: "2.6.3"
+      version: "2.6.4"
 # Script Security (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "script-security"
     source:
-      version: "1.74"
+      version: "1.75"
 # Snakeyaml API (Jenkins-Version: 2.204.6)
   - groupId: "io.jenkins.plugins"
     artifactId: "snakeyaml-api"
     source:
-      version: "1.26.4"
+      version: "1.27.0"
 # SSH Credentials (Jenkins-Version: 2.190.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "ssh-credentials"
@@ -469,11 +469,11 @@ plugins:
     artifactId: "token-macro"
     source:
       version: "2.12"
-# Trilead API (Jenkins-Version: 2.184)
+# Trilead API (Jenkins-Version: 2.204)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "trilead-api"
     source:
-      version: "1.0.8"
+      version: "1.0.11"
 # Variant (Jenkins-Version: 2.60.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "variant"
@@ -498,27 +498,27 @@ plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-basic-steps"
     source:
-      version: "2.20"
+      version: "2.21"
 # Pipeline: Groovy (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-cps"
     source:
-      version: "2.82"
+      version: "2.83"
 # Pipeline: Shared Groovy Libraries (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-cps-global-lib"
     source:
       version: "2.17"
-# Pipeline: Nodes and Processes (Jenkins-Version: 2.176.1)
+# Pipeline: Nodes and Processes (Jenkins-Version: 2.248)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-durable-task-step"
     source:
-      version: "2.35"
-# Pipeline: Job (Jenkins-Version: 2.138.4)
+      version: "2.36"
+# Pipeline: Job (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"
     source:
-      version: "2.39"
+      version: "2.40"
 # Pipeline: Multibranch (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-multibranch"

--- a/jenkinsfile-runner-steward-image/Dockerfile
+++ b/jenkinsfile-runner-steward-image/Dockerfile
@@ -1,6 +1,5 @@
 FROM jenkinsfile-runner-base-local as packager-output
-# adoptopenjdk/openjdk11:x86_64-alpine-jdk-11.0.7_10-slim
-FROM adoptopenjdk/openjdk11@sha256:1b5a395ba0eb4d4fa8fc2ced4471e43044681d5541a7fe11b1f0c20f0f6104db
+FROM adoptopenjdk/openjdk11:x86_64-alpine-jdk-11.0.8_10-slim
 
 RUN apk add jq xmlstarlet bash git curl
 RUN addgroup -g 1000 jenkins && adduser -D -u 1000 -G jenkins jenkins

--- a/jenkinsfile-runner-steward-image/Dockerfile
+++ b/jenkinsfile-runner-steward-image/Dockerfile
@@ -1,5 +1,6 @@
 FROM jenkinsfile-runner-base-local as packager-output
-FROM adoptopenjdk/openjdk11:x86_64-alpine-jdk-11.0.8_10-slim
+# adoptopenjdk/openjdk11:x86_64-alpine-jdk-11.0.8_10-slim
+FROM adoptopenjdk/openjdk11@sha256:925eed1e2003bb2b9a80c77e9080c4d5b229f49ec51eac472db69b42f6072331
 
 RUN apk add jq xmlstarlet bash git curl
 RUN addgroup -g 1000 jenkins && adduser -D -u 1000 -G jenkins jenkins

--- a/jenkinsfile-runner-steward-image/Dockerfile
+++ b/jenkinsfile-runner-steward-image/Dockerfile
@@ -1,5 +1,6 @@
 FROM jenkinsfile-runner-base-local as packager-output
-FROM openjdk:8-alpine3.9
+# adoptopenjdk/openjdk11:x86_64-alpine-jdk-11.0.7_10-slim
+FROM adoptopenjdk/openjdk11@sha256:1b5a395ba0eb4d4fa8fc2ced4471e43044681d5541a7fe11b1f0c20f0f6104db
 
 RUN apk add jq xmlstarlet bash git curl
 RUN addgroup -g 1000 jenkins && adduser -D -u 1000 -G jenkins jenkins


### PR DESCRIPTION
**NOTE1:** kubernetes plugin versions 1.27.1 and 1.27.1.1 have a bug. Pipelines will hang at waiting for a dynamic-agent to be ready.
**NOTE2:** As also discussed in this PR https://github.com/SAP/stewardci-jenkinsfilerunner-image/pull/49 warnings-ng plugin versions from 8.4.1 up to the current latest version (8.4.4) have a bug. We saw this exception in S4SDK pipeline: `java.lang.IllegalStateException: Root URL isn't configured yet. Cannot compute absolute URL`
