### PR TITLE
Updated plugins and Jenkins Core - removed analysis-core

### DIFF
--- a/jenkinsfile-runner-base-image/packager-config.yml
+++ b/jenkinsfile-runner-base-image/packager-config.yml
@@ -21,7 +21,7 @@ buildSettings:
         git: https://github.com/SAP/stewardci-jenkinsfilerunner-image
         branch: "jenkinsfile-runner--1.0-beta-19-steward-1"
     docker:
-      base: "jenkins/jenkins:2.263.2-alpine"
+      base: "jenkins/jenkins:2.277.4-alpine"
       tag: "jenkinsfile-runner-base-local"
       build: true
 
@@ -29,7 +29,7 @@ war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.263.2"
+    version: "2.277.4"
 
 systemProperties:
     jenkins.model.Jenkins.slaveAgentPort: "50000"
@@ -67,11 +67,11 @@ plugins:
     artifactId: "ace-editor"
     source:
       version: "1.1"
-# Analysis Model API (Jenkins-Version: 2.204.6)
+# Analysis Model API (Jenkins-Version: 2.249.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "analysis-model-api"
     source:
-      version: "9.6.0"
+      version: "10.2.1"
 # OWASP Markup Formatter (Jenkins-Version: 2.121.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "antisamy-markup-formatter"
@@ -92,31 +92,36 @@ plugins:
     artifactId: "badge"
     source:
       version: "1.8"
-# Bootstrap 4 API (Jenkins-Version: 2.204.6)
+# Bootstrap 4 API (Jenkins-Version: 2.249.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "bootstrap4-api"
     source:
-      version: "4.5.3-1"
-# bouncycastle API (Jenkins-Version: 2.60.3)
+      version: "4.6.0-3"
+# bouncycastle API (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "bouncycastle-api"
     source:
-      version: "2.18"
-# Branch API (Jenkins-Version: 2.264)
+      version: "2.20"
+# Branch API (Jenkins-Version: 2.277.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "branch-api"
     source:
-      version: "2.6.3"
+      version: "2.6.4"
 # Build Timeout (Jenkins-Version: 2.222.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "build-timeout"
     source:
       version: "1.20"
-# Checks API (Jenkins-Version: 2.204.6)
+# Caffeine API (Jenkins-Version: 2.222.1)
+  - groupId: "io.jenkins.plugins"
+    artifactId: "caffeine-api"
+    source:
+      version: "2.9.1-23.v51c4e2c879c8"
+# Checks API (Jenkins-Version: 2.249.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "checks-api"
     source:
-      version: "1.2.0"
+      version: "1.7.0"
 # Folders (Jenkins-Version: 2.204.6)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "cloudbees-folder"
@@ -127,16 +132,16 @@ plugins:
     artifactId: "cobertura"
     source:
       version: "1.16"
-# Code Coverage API (Jenkins-Version: 2.204.6)
+# Code Coverage API (Jenkins-Version: 2.222.4)
   - groupId: "io.jenkins.plugins"
     artifactId: "code-coverage-api"
     source:
-      version: "1.2.0"
-# Configuration as Code (Jenkins-Version: 2.222)
+      version: "1.3.2"
+# Configuration as Code (Jenkins-Version: 2.222.1)
   - groupId: "io.jenkins"
     artifactId: "configuration-as-code"
     source:
-      version: "1.46"
+      version: "1.50"
 # Configuration as Code Plugin - Groovy Scripting Extension (Jenkins-Version: 2.60.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "configuration-as-code-groovy"
@@ -146,7 +151,7 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "credentials"
     source:
-      version: "2.3.14"
+      version: "2.3.18"
 # Credentials Binding (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "credentials-binding"
@@ -157,11 +162,11 @@ plugins:
     artifactId: "cucumber-testresult-plugin"
     source:
       version: "0.10.1"
-# DataTables.net API (Jenkins-Version: 2.204.6)
+# DataTables.net API (Jenkins-Version: 2.249.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "data-tables-api"
     source:
-      version: "1.10.21-3"
+      version: "1.10.23-3"
 # Display URL API (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "display-url-api"
@@ -171,72 +176,72 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "durable-task"
     source:
-      version: "1.35"
-# ECharts API (Jenkins-Version: 2.204.6)
+      version: "1.36"
+# ECharts API (Jenkins-Version: 2.249.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "echarts-api"
     source:
-      version: "4.9.0-3"
+      version: "5.1.0-2"
 # Email Extension (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "email-ext"
     source:
-      version: "2.81"
-# Font Awesome API (Jenkins-Version: 2.204.6)
+      version: "2.82"
+# Font Awesome API (Jenkins-Version: 2.249.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "font-awesome-api"
     source:
-      version: "5.15.1-1"
-# Forensics API (Jenkins-Version: 2.204.6)
+      version: "5.15.2-2"
+# Forensics API (Jenkins-Version: 2.249.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "forensics-api"
     source:
-      version: "0.8.1"
+      version: "1.0.0"
 # Gatling (Jenkins-Version: 2.150.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "gatling"
     source:
       version: "1.3.0"
-# Git (Jenkins-Version: 2.222.4)
+# Git (Jenkins-Version: 2.263.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "git"
     source:
-      version: "4.5.2"
-# Git client (Jenkins-Version: 2.222.4)
+      version: "4.7.1"
+# Git client (Jenkins-Version: 2.263.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "git-client"
     source:
-      version: "3.6.0"
+      version: "3.7.1"
 # GIT server (Jenkins-Version: 2.138.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "git-server"
     source:
       version: "1.9"
-# GitHub (Jenkins-Version: 2.164.3)
+# GitHub (Jenkins-Version: 2.222.4)
   - groupId: "com.coravy.hudson.plugins.github"
     artifactId: "github"
     source:
-      version: "1.32.0"
+      version: "1.33.1"
 # GitHub API (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "github-api"
     source:
-      version: "1.122"
-# GitHub Branch Source (Jenkins-Version: 2.176.4)
+      version: "1.123"
+# GitHub Branch Source (Jenkins-Version: 2.283)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "github-branch-source"
     source:
-      version: "2.9.3"
+      version: "2.10.3"
 # Gradle (Jenkins-Version: 2.138.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "gradle"
     source:
       version: "1.36"
-# JavaScript GUI Lib: Handlebars bundle (Jenkins-Version: 1.580.1)
+# JavaScript GUI Lib: Handlebars bundle (Jenkins-Version: 2.204)
   - groupId: "org.jenkins-ci.ui"
     artifactId: "handlebars"
     source:
-      version: "1.1.1"
+      version: "3.0.8"
 # HTML Publisher (Jenkins-Version: 2.164.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "htmlpublisher"
@@ -246,27 +251,32 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "http_request"
     source:
-      version: "1.8.27"
+      version: "1.9.0"
 # InfluxDB (Jenkins-Version: 2.195)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "influxdb"
     source:
-      version: "2.5"
+      version: "3.0"
 # Jackson 2 API (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "jackson2-api"
     source:
-      version: "2.12.1"
+      version: "2.12.3"
 # JaCoCo (Jenkins-Version: 2.164.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "jacoco"
     source:
-      version: "3.1.0"
-# JQuery3 API (Jenkins-Version: 2.204.6)
+      version: "3.1.1"
+# Java JSON Web Token (JJWT) (Jenkins-Version: 2.222.4)
+  - groupId: "io.jenkins.plugins"
+    artifactId: "jjwt-api"
+    source:
+      version: "0.11.2-9.c8b45b8bb173"
+# JQuery3 API (Jenkins-Version: 2.249.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "jquery3-api"
     source:
-      version: "3.5.1-2"
+      version: "3.6.0-1"
 # JSch dependency (Jenkins-Version: 2.190.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "jsch"
@@ -276,17 +286,17 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "junit"
     source:
-      version: "1.48"
+      version: "1.49"
 # Kubernetes (Jenkins-Version: 2.263)
   - groupId: "org.csanchez.jenkins.plugins"
     artifactId: "kubernetes"
     source:
-      version: "1.28.7"
+      version: "1.29.4"
 # Kubernetes Client API (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "kubernetes-client-api"
     source:
-      version: "4.11.1"
+      version: "4.13.3-1"
 # Kubernetes Credentials (Jenkins-Version: 2.204.6)
   - groupId: "org.jenkinsci.plugins"
     artifactId: "kubernetes-credentials"
@@ -296,17 +306,17 @@ plugins:
   - groupId: "com.cloudbees.jenkins.plugins"
     artifactId: "kubernetes-credentials-provider"
     source:
-      version: "0.15"
+      version: "0.18-1"
 # Lockable Resources (Jenkins-Version: 2.138.4)
   - groupId: "org.6wind.jenkins"
     artifactId: "lockable-resources"
     source:
       version: "2.10"
-# Mailer (Jenkins-Version: 2.150.1)
+# Mailer (Jenkins-Version: 2.235.5)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "mailer"
     source:
-      version: "1.32.1"
+      version: "1.34"
 # Matrix Project (Jenkins-Version: 2.164.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "matrix-project"
@@ -352,26 +362,26 @@ plugins:
     artifactId: "pipeline-input-step"
     source:
       version: "2.12"
-# Pipeline: Milestone Step (Jenkins-Version: 1.642.3)
+# Pipeline: Milestone Step (Jenkins-Version: 2.60.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "pipeline-milestone-step"
     source:
-      version: "1.3.1"
-# Pipeline: Model API (Jenkins-Version: 2.176.4)
+      version: "1.3.2"
+# Pipeline: Model API (Jenkins-Version: 2.190.3)
   - groupId: "org.jenkinsci.plugins"
     artifactId: "pipeline-model-api"
     source:
-      version: "1.7.2"
-# Pipeline: Declarative (Jenkins-Version: 2.176.4)
+      version: "1.8.4"
+# Pipeline: Declarative (Jenkins-Version: 2.190.3)
   - groupId: "org.jenkinsci.plugins"
     artifactId: "pipeline-model-definition"
     source:
-      version: "1.7.2"
-# Pipeline: Declarative Extension Points API (Jenkins-Version: 2.176.4)
+      version: "1.8.4"
+# Pipeline: Declarative Extension Points API (Jenkins-Version: 2.190.3)
   - groupId: "org.jenkinsci.plugins"
     artifactId: "pipeline-model-extensions"
     source:
-      version: "1.7.2"
+      version: "1.8.4"
 # Pipeline: REST API (Jenkins-Version: 2.60.3)
   - groupId: "org.jenkins-ci.plugins.pipeline-stage-view"
     artifactId: "pipeline-rest-api"
@@ -382,11 +392,11 @@ plugins:
     artifactId: "pipeline-stage-step"
     source:
       version: "2.5"
-# Pipeline: Stage Tags Metadata (Jenkins-Version: 2.176.4)
+# Pipeline: Stage Tags Metadata (Jenkins-Version: 2.190.3)
   - groupId: "org.jenkinsci.plugins"
     artifactId: "pipeline-stage-tags-metadata"
     source:
-      version: "1.7.2"
+      version: "1.8.4"
 # Pipeline: Stage View (Jenkins-Version: 2.60.3)
   - groupId: "org.jenkins-ci.plugins.pipeline-stage-view"
     artifactId: "pipeline-stage-view"
@@ -396,27 +406,27 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "pipeline-utility-steps"
     source:
-      version: "2.6.1"
+      version: "2.7.1"
 # Plain Credentials (Jenkins-Version: 2.138.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "plain-credentials"
     source:
       version: "1.7"
-# Plugin Utilities API (Jenkins-Version: 2.204.6)
+# Plugin Utilities API (Jenkins-Version: 2.249.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "plugin-util-api"
     source:
-      version: "1.6.1"
-# Popper.js API (Jenkins-Version: 2.204.6)
+      version: "2.1.0"
+# Popper.js API (Jenkins-Version: 2.249.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "popper-api"
     source:
-      version: "1.16.0-7"
-# Resource Disposer (Jenkins-Version: 2.54)
+      version: "1.16.1-2"
+# Resource Disposer (Jenkins-Version: 2.164.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "resource-disposer"
     source:
-      version: "0.14"
+      version: "0.15"
 # SCM API (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "scm-api"
@@ -426,32 +436,32 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "script-security"
     source:
-      version: "1.75"
+      version: "1.76"
 # Snakeyaml API (Jenkins-Version: 2.204.6)
   - groupId: "io.jenkins.plugins"
     artifactId: "snakeyaml-api"
     source:
       version: "1.27.0"
-# SSH Credentials (Jenkins-Version: 2.190.1)
+# SSH Credentials (Jenkins-Version: 2.282)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "ssh-credentials"
     source:
-      version: "1.18.1"
-# Structs (Jenkins-Version: 2.107.3)
+      version: "1.18.2"
+# Structs (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "structs"
     source:
-      version: "1.20"
-# Timestamper (Jenkins-Version: 2.204.6)
+      version: "1.22"
+# Timestamper (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "timestamper"
     source:
-      version: "1.11.8"
+      version: "1.12"
 # Token Macro (Jenkins-Version: 2.274)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "token-macro"
     source:
-      version: "2.14"
+      version: "2.15"
 # Trilead API (Jenkins-Version: 2.204)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "trilead-api"
@@ -462,69 +472,69 @@ plugins:
     artifactId: "variant"
     source:
       version: "1.4"
-# Warnings Next Generation (Jenkins-Version: 2.204.6)
+# Warnings Next Generation (Jenkins-Version: 2.249.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "warnings-ng"
     source:
-      version: "8.3.0"
+      version: "9.0.1"
 # Pipeline (Jenkins-Version: 2.130)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-aggregator"
     source:
       version: "2.6"
-# Pipeline: API (Jenkins-Version: 2.176.4)
+# Pipeline: API (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-api"
     source:
-      version: "2.41"
+      version: "2.42"
 # Pipeline: Basic Steps (Jenkins-Version: 2.263)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-basic-steps"
     source:
       version: "2.23"
-# Pipeline: Groovy (Jenkins-Version: 2.176.4)
+# Pipeline: Groovy (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-cps"
     source:
-      version: "2.87"
-# Pipeline: Shared Groovy Libraries (Jenkins-Version: 2.176.4)
+      version: "2.90"
+# Pipeline: Shared Groovy Libraries (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-cps-global-lib"
     source:
-      version: "2.17"
+      version: "2.19"
 # Pipeline: Nodes and Processes (Jenkins-Version: 2.248)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-durable-task-step"
     source:
-      version: "2.37"
+      version: "2.38"
 # Pipeline: Job (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"
     source:
       version: "2.40"
-# Pipeline: Multibranch (Jenkins-Version: 2.176.4)
+# Pipeline: Multibranch (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-multibranch"
     source:
-      version: "2.22"
-# Pipeline: SCM Step (Jenkins-Version: 2.60)
+      version: "2.23"
+# Pipeline: SCM Step (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-scm-step"
     source:
-      version: "2.11"
+      version: "2.12"
 # Pipeline: Step API (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-step-api"
     source:
       version: "2.23"
-# Pipeline: Supporting APIs (Jenkins-Version: 2.176.4)
+# Pipeline: Supporting APIs (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-support"
     source:
-      version: "3.7"
-# Workspace Cleanup (Jenkins-Version: 2.121)
+      version: "3.8"
+# Workspace Cleanup (Jenkins-Version: 2.164.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "ws-cleanup"
     source:
-      version: "0.38"
+      version: "0.39"
 ##PLUGINS-END (do not remove!)

--- a/jenkinsfile-runner-base-image/packager-config.yml
+++ b/jenkinsfile-runner-base-image/packager-config.yml
@@ -87,11 +87,6 @@ plugins:
     artifactId: "authentication-tokens"
     source:
       version: "1.4"
-# Badge (Jenkins-Version: 2.60.3)
-  - groupId: "org.jenkins-ci.plugins"
-    artifactId: "badge"
-    source:
-      version: "1.8"
 # Bootstrap 4 API (Jenkins-Version: 2.249.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "bootstrap4-api"
@@ -141,7 +136,7 @@ plugins:
   - groupId: "io.jenkins"
     artifactId: "configuration-as-code"
     source:
-      version: "1.50"
+      version: "1.51"
 # Configuration as Code Plugin - Groovy Scripting Extension (Jenkins-Version: 2.60.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "configuration-as-code-groovy"
@@ -151,7 +146,7 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "credentials"
     source:
-      version: "2.3.18"
+      version: "2.3.19"
 # Credentials Binding (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "credentials-binding"
@@ -182,16 +177,11 @@ plugins:
     artifactId: "echarts-api"
     source:
       version: "5.1.0-2"
-# Email Extension (Jenkins-Version: 2.222.4)
-  - groupId: "org.jenkins-ci.plugins"
-    artifactId: "email-ext"
-    source:
-      version: "2.82"
 # Font Awesome API (Jenkins-Version: 2.249.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "font-awesome-api"
     source:
-      version: "5.15.2-2"
+      version: "5.15.3-2"
 # Forensics API (Jenkins-Version: 2.249.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "forensics-api"
@@ -227,11 +217,11 @@ plugins:
     artifactId: "github-api"
     source:
       version: "1.123"
-# GitHub Branch Source (Jenkins-Version: 2.271)
+# GitHub Branch Source (Jenkins-Version: 2.277.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "github-branch-source"
     source:
-      version: "2.10.2"
+      version: "2.10.4"
 # Gradle (Jenkins-Version: 2.138.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "gradle"
@@ -451,12 +441,12 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "structs"
     source:
-      version: "1.22"
+      version: "1.23"
 # Timestamper (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "timestamper"
     source:
-      version: "1.12"
+      version: "1.13"
 # Token Macro (Jenkins-Version: 2.274)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "token-macro"
@@ -496,7 +486,7 @@ plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-cps"
     source:
-      version: "2.90"
+      version: "2.91"
 # Pipeline: Shared Groovy Libraries (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-cps-global-lib"

--- a/jenkinsfile-runner-base-image/packager-config.yml
+++ b/jenkinsfile-runner-base-image/packager-config.yml
@@ -463,7 +463,7 @@ plugins:
   - groupId: "io.jenkins.plugins"
     artifactId: "warnings-ng"
     source:
-      version: "8.6.3"
+      version: "8.3.0"
 # Pipeline (Jenkins-Version: 2.130)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-aggregator"

--- a/jenkinsfile-runner-base-image/packager-config.yml
+++ b/jenkinsfile-runner-base-image/packager-config.yml
@@ -463,7 +463,7 @@ plugins:
   - groupId: "io.jenkins.plugins"
     artifactId: "warnings-ng"
     source:
-      version: "8.4.4"
+      version: "8.3.0"
 # Pipeline (Jenkins-Version: 2.130)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-aggregator"

--- a/jenkinsfile-runner-base-image/packager-config.yml
+++ b/jenkinsfile-runner-base-image/packager-config.yml
@@ -21,7 +21,7 @@ buildSettings:
         git: https://github.com/SAP/stewardci-jenkinsfilerunner-image
         branch: "jenkinsfile-runner--1.0-beta-27-steward-1"
     docker:
-      base: "jenkins/jenkins:2.277.4-alpine"
+      base: "jenkins/jenkins:2.291-alpine"
       tag: "jenkinsfile-runner-base-local"
       build: true
 
@@ -29,7 +29,7 @@ war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.277.4"
+    version: "2.291"
 
 systemProperties:
     jenkins.model.Jenkins.slaveAgentPort: "50000"
@@ -71,7 +71,7 @@ plugins:
   - groupId: "io.jenkins.plugins"
     artifactId: "analysis-model-api"
     source:
-      version: "10.2.1"
+      version: "10.2.5"
 # OWASP Markup Formatter (Jenkins-Version: 2.121.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "antisamy-markup-formatter"
@@ -416,7 +416,7 @@ plugins:
   - groupId: "io.jenkins.plugins"
     artifactId: "plugin-util-api"
     source:
-      version: "2.1.0"
+      version: "2.2.0"
 # Popper.js API (Jenkins-Version: 2.249.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "popper-api"
@@ -476,7 +476,7 @@ plugins:
   - groupId: "io.jenkins.plugins"
     artifactId: "warnings-ng"
     source:
-      version: "9.0.1"
+      version: "9.1.0"
 # Pipeline (Jenkins-Version: 2.130)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-aggregator"

--- a/jenkinsfile-runner-base-image/packager-config.yml
+++ b/jenkinsfile-runner-base-image/packager-config.yml
@@ -18,7 +18,7 @@ buildSettings:
         git: https://github.com/jenkinsci/jenkinsfile-runner.git
         branch: "1.0-beta-19"
     docker:
-      base: "jenkins/jenkins:2.249.2-alpine"
+      base: "jenkins/jenkins:2.263.1-alpine"
       tag: "jenkinsfile-runner-base-local"
       build: true
 
@@ -26,7 +26,7 @@ war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.249.2"
+    version: "2.263.1"
 
 systemProperties:
     jenkins.model.Jenkins.slaveAgentPort: "50000"
@@ -64,21 +64,11 @@ plugins:
     artifactId: "ace-editor"
     source:
       version: "1.1"
-# Static Analysis Collector (Jenkins-Version: 1.625.1)
-  - groupId: "org.jvnet.hudson.plugins"
-    artifactId: "analysis-collector"
-    source:
-      version: "2.0.0"
-# Static Analysis Utilities (Jenkins-Version: 1.625.1)
-  - groupId: "org.jvnet.hudson.plugins"
-    artifactId: "analysis-core"
-    source:
-      version: "1.96"
 # Analysis Model API (Jenkins-Version: 2.204.6)
   - groupId: "io.jenkins.plugins"
     artifactId: "analysis-model-api"
     source:
-      version: "9.2.1"
+      version: "9.4.0"
 # OWASP Markup Formatter (Jenkins-Version: 2.121.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "antisamy-markup-formatter"
@@ -109,11 +99,11 @@ plugins:
     artifactId: "bouncycastle-api"
     source:
       version: "2.18"
-# Branch API (Jenkins-Version: 2.176.4)
+# Branch API (Jenkins-Version: 2.264)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "branch-api"
     source:
-      version: "2.6.0"
+      version: "2.6.3"
 # Build Timeout (Jenkins-Version: 2.222.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "build-timeout"
@@ -123,12 +113,12 @@ plugins:
   - groupId: "io.jenkins.plugins"
     artifactId: "checks-api"
     source:
-      version: "1.0.3"
-# Folders (Jenkins-Version: 2.176.1)
+      version: "1.1.1"
+# Folders (Jenkins-Version: 2.204.6)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "cloudbees-folder"
     source:
-      version: "6.14"
+      version: "6.15"
 # Cobertura (Jenkins-Version: 2.60.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "cobertura"
@@ -143,7 +133,7 @@ plugins:
   - groupId: "io.jenkins"
     artifactId: "configuration-as-code"
     source:
-      version: "1.45"
+      version: "1.46"
 # Configuration as Code Plugin - Groovy Scripting Extension (Jenkins-Version: 2.60.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "configuration-as-code-groovy"
@@ -153,7 +143,7 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "credentials"
     source:
-      version: "2.3.13"
+      version: "2.3.14"
 # Credentials Binding (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "credentials-binding"
@@ -173,7 +163,7 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "display-url-api"
     source:
-      version: "2.3.3"
+      version: "2.3.4"
 # Durable Task (Jenkins-Version: 2.150.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "durable-task"
@@ -188,7 +178,7 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "email-ext"
     source:
-      version: "2.77"
+      version: "2.80"
 # Font Awesome API (Jenkins-Version: 2.204.6)
   - groupId: "io.jenkins.plugins"
     artifactId: "font-awesome-api"
@@ -204,11 +194,11 @@ plugins:
     artifactId: "gatling"
     source:
       version: "1.3.0"
-# Git (Jenkins-Version: 2.204.1)
+# Git (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "git"
     source:
-      version: "4.4.5"
+      version: "4.5.0"
 # Git client (Jenkins-Version: 2.204.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "git-client"
@@ -223,17 +213,17 @@ plugins:
   - groupId: "com.coravy.hudson.plugins.github"
     artifactId: "github"
     source:
-      version: "1.31.0"
+      version: "1.32.0"
 # GitHub API (Jenkins-Version: 2.164.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "github-api"
     source:
-      version: "1.116"
+      version: "1.117"
 # GitHub Branch Source (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "github-branch-source"
     source:
-      version: "2.9.1"
+      version: "2.9.2"
 # Gradle (Jenkins-Version: 2.138.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "gradle"
@@ -248,12 +238,12 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "htmlpublisher"
     source:
-      version: "1.23"
-# HTTP Request (Jenkins-Version: 2.60.3)
+      version: "1.25"
+# HTTP Request (Jenkins-Version: 2.204.6)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "http_request"
     source:
-      version: "1.8.26"
+      version: "1.8.27"
 # InfluxDB (Jenkins-Version: 2.195)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "influxdb"
@@ -263,22 +253,12 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "jackson2-api"
     source:
-      version: "2.11.3"
-# JaCoCo (Jenkins-Version: 2.150.3)
+      version: "2.12.0"
+# JaCoCo (Jenkins-Version: 2.164.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "jacoco"
     source:
-      version: "3.0.8"
-# Javadoc (Jenkins-Version: 2.60.3)
-  - groupId: "org.jenkins-ci.plugins"
-    artifactId: "javadoc"
-    source:
-      version: "1.6"
-# JavaScript GUI Lib: jQuery bundles (jQuery and jQuery UI) (Jenkins-Version: 1.580.1)
-  - groupId: "org.jenkins-ci.ui"
-    artifactId: "jquery-detached"
-    source:
-      version: "1.2.1"
+      version: "3.1.0"
 # JQuery3 API (Jenkins-Version: 2.204.6)
   - groupId: "io.jenkins.plugins"
     artifactId: "jquery3-api"
@@ -293,12 +273,12 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "junit"
     source:
-      version: "1.43"
-# Kubernetes (Jenkins-Version: 2.222.4)
+      version: "1.46"
+# Kubernetes (Jenkins-Version: 2.263)
   - groupId: "org.csanchez.jenkins.plugins"
     artifactId: "kubernetes"
     source:
-      version: "1.27.3"
+      version: "1.28.3"
 # Kubernetes Client API (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "kubernetes-client-api"
@@ -329,11 +309,11 @@ plugins:
     artifactId: "matrix-project"
     source:
       version: "1.18"
-# Maven Integration (Jenkins-Version: 2.204.6)
-  - groupId: "org.jenkins-ci.main"
-    artifactId: "maven-plugin"
+# Metrics (Jenkins-Version: 2.60.3)
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "metrics"
     source:
-      version: "3.8"
+      version: "4.0.2.6"
 # JavaScript GUI Lib: Moment.js bundle (Jenkins-Version: 1.580.1)
   - groupId: "org.jenkins-ci.ui"
     artifactId: "momentjs"
@@ -393,7 +373,7 @@ plugins:
   - groupId: "org.jenkins-ci.plugins.pipeline-stage-view"
     artifactId: "pipeline-rest-api"
     source:
-      version: "2.18"
+      version: "2.19"
 # Pipeline: Stage Step (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "pipeline-stage-step"
@@ -408,7 +388,7 @@ plugins:
   - groupId: "org.jenkins-ci.plugins.pipeline-stage-view"
     artifactId: "pipeline-stage-view"
     source:
-      version: "2.18"
+      version: "2.19"
 # Pipeline Utility Steps (Jenkins-Version: 2.121.2)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "pipeline-utility-steps"
@@ -423,7 +403,7 @@ plugins:
   - groupId: "io.jenkins.plugins"
     artifactId: "plugin-util-api"
     source:
-      version: "1.4.0"
+      version: "1.5.0"
 # Popper.js API (Jenkins-Version: 2.204.6)
   - groupId: "io.jenkins.plugins"
     artifactId: "popper-api"
@@ -473,7 +453,7 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "trilead-api"
     source:
-      version: "1.0.12"
+      version: "1.0.13"
 # Variant (Jenkins-Version: 2.60.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "variant"
@@ -483,7 +463,7 @@ plugins:
   - groupId: "io.jenkins.plugins"
     artifactId: "warnings-ng"
     source:
-      version: "8.3.0"
+      version: "8.4.4"
 # Pipeline (Jenkins-Version: 2.130)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-aggregator"
@@ -494,16 +474,16 @@ plugins:
     artifactId: "workflow-api"
     source:
       version: "2.40"
-# Pipeline: Basic Steps (Jenkins-Version: 2.249.1)
+# Pipeline: Basic Steps (Jenkins-Version: 2.263)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-basic-steps"
     source:
-      version: "2.22"
+      version: "2.23"
 # Pipeline: Groovy (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-cps"
     source:
-      version: "2.83"
+      version: "2.87"
 # Pipeline: Shared Groovy Libraries (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-cps-global-lib"
@@ -513,7 +493,7 @@ plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-durable-task-step"
     source:
-      version: "2.36"
+      version: "2.37"
 # Pipeline: Job (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"
@@ -538,7 +518,7 @@ plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-support"
     source:
-      version: "3.5"
+      version: "3.7"
 # Workspace Cleanup (Jenkins-Version: 2.121)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "ws-cleanup"

--- a/jenkinsfile-runner-base-image/packager-config.yml
+++ b/jenkinsfile-runner-base-image/packager-config.yml
@@ -18,7 +18,7 @@ buildSettings:
         git: https://github.com/jenkinsci/jenkinsfile-runner.git
         branch: "1.0-beta-19"
     docker:
-      base: "jenkins/jenkins:2.263.1-alpine"
+      base: "jenkins/jenkins:2.263.2-alpine"
       tag: "jenkinsfile-runner-base-local"
       build: true
 
@@ -26,7 +26,7 @@ war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.263.1"
+    version: "2.263.2"
 
 systemProperties:
     jenkins.model.Jenkins.slaveAgentPort: "50000"
@@ -68,7 +68,7 @@ plugins:
   - groupId: "io.jenkins.plugins"
     artifactId: "analysis-model-api"
     source:
-      version: "9.4.0"
+      version: "9.6.0"
 # OWASP Markup Formatter (Jenkins-Version: 2.121.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "antisamy-markup-formatter"
@@ -78,7 +78,7 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "apache-httpcomponents-client-4-api"
     source:
-      version: "4.5.10-2.0"
+      version: "4.5.13-1.0"
 # Authentication Tokens API (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "authentication-tokens"
@@ -113,7 +113,7 @@ plugins:
   - groupId: "io.jenkins.plugins"
     artifactId: "checks-api"
     source:
-      version: "1.1.1"
+      version: "1.2.0"
 # Folders (Jenkins-Version: 2.204.6)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "cloudbees-folder"
@@ -173,22 +173,22 @@ plugins:
   - groupId: "io.jenkins.plugins"
     artifactId: "echarts-api"
     source:
-      version: "4.9.0-2"
-# Email Extension (Jenkins-Version: 2.164.3)
+      version: "4.9.0-3"
+# Email Extension (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "email-ext"
     source:
-      version: "2.80"
+      version: "2.81"
 # Font Awesome API (Jenkins-Version: 2.204.6)
   - groupId: "io.jenkins.plugins"
     artifactId: "font-awesome-api"
     source:
       version: "5.15.1-1"
-# Forensics API (Jenkins-Version: 2.138.4)
+# Forensics API (Jenkins-Version: 2.204.6)
   - groupId: "io.jenkins.plugins"
     artifactId: "forensics-api"
     source:
-      version: "0.7.0"
+      version: "0.8.1"
 # Gatling (Jenkins-Version: 2.150.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "gatling"
@@ -198,12 +198,12 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "git"
     source:
-      version: "4.5.0"
-# Git client (Jenkins-Version: 2.204.1)
+      version: "4.5.2"
+# Git client (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "git-client"
     source:
-      version: "3.5.1"
+      version: "3.6.0"
 # GIT server (Jenkins-Version: 2.138.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "git-server"
@@ -214,16 +214,16 @@ plugins:
     artifactId: "github"
     source:
       version: "1.32.0"
-# GitHub API (Jenkins-Version: 2.164.3)
+# GitHub API (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "github-api"
     source:
-      version: "1.117"
+      version: "1.122"
 # GitHub Branch Source (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "github-branch-source"
     source:
-      version: "2.9.2"
+      version: "2.9.3"
 # Gradle (Jenkins-Version: 2.138.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "gradle"
@@ -253,7 +253,7 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "jackson2-api"
     source:
-      version: "2.12.0"
+      version: "2.12.1"
 # JaCoCo (Jenkins-Version: 2.164.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "jacoco"
@@ -273,12 +273,12 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "junit"
     source:
-      version: "1.46"
+      version: "1.48"
 # Kubernetes (Jenkins-Version: 2.263)
   - groupId: "org.csanchez.jenkins.plugins"
     artifactId: "kubernetes"
     source:
-      version: "1.28.3"
+      version: "1.28.7"
 # Kubernetes Client API (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "kubernetes-client-api"
@@ -288,7 +288,7 @@ plugins:
   - groupId: "org.jenkinsci.plugins"
     artifactId: "kubernetes-credentials"
     source:
-      version: "0.7.0"
+      version: "0.8.0"
 # Kubernetes Credentials Provider (Jenkins-Version: 2.190.1)
   - groupId: "com.cloudbees.jenkins.plugins"
     artifactId: "kubernetes-credentials-provider"
@@ -309,11 +309,11 @@ plugins:
     artifactId: "matrix-project"
     source:
       version: "1.18"
-# Metrics (Jenkins-Version: 2.60.3)
+# Metrics (Jenkins-Version: 2.222.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "metrics"
     source:
-      version: "4.0.2.6"
+      version: "4.0.2.7"
 # JavaScript GUI Lib: Moment.js bundle (Jenkins-Version: 1.580.1)
   - groupId: "org.jenkins-ci.ui"
     artifactId: "momentjs"
@@ -403,7 +403,7 @@ plugins:
   - groupId: "io.jenkins.plugins"
     artifactId: "plugin-util-api"
     source:
-      version: "1.5.0"
+      version: "1.6.1"
 # Popper.js API (Jenkins-Version: 2.204.6)
   - groupId: "io.jenkins.plugins"
     artifactId: "popper-api"
@@ -444,36 +444,36 @@ plugins:
     artifactId: "timestamper"
     source:
       version: "1.11.8"
-# Token Macro (Jenkins-Version: 2.121.3)
+# Token Macro (Jenkins-Version: 2.274)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "token-macro"
     source:
-      version: "2.12"
+      version: "2.14"
 # Trilead API (Jenkins-Version: 2.204)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "trilead-api"
     source:
       version: "1.0.13"
-# Variant (Jenkins-Version: 2.60.3)
+# Variant (Jenkins-Version: 2.249.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "variant"
     source:
-      version: "1.3"
+      version: "1.4"
 # Warnings Next Generation (Jenkins-Version: 2.204.6)
   - groupId: "io.jenkins.plugins"
     artifactId: "warnings-ng"
     source:
-      version: "8.3.0"
+      version: "8.6.3"
 # Pipeline (Jenkins-Version: 2.130)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-aggregator"
     source:
       version: "2.6"
-# Pipeline: API (Jenkins-Version: 2.150.3)
+# Pipeline: API (Jenkins-Version: 2.176.4)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-api"
     source:
-      version: "2.40"
+      version: "2.41"
 # Pipeline: Basic Steps (Jenkins-Version: 2.263)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-basic-steps"

--- a/jenkinsfile-runner-base-image/packager-config.yml
+++ b/jenkinsfile-runner-base-image/packager-config.yml
@@ -21,7 +21,7 @@ buildSettings:
         git: https://github.com/SAP/stewardci-jenkinsfilerunner-image
         branch: "jenkinsfile-runner--1.0-beta-27-steward-1"
     docker:
-      base: "jenkins/jenkins:2.291-alpine"
+      base: "jenkins/jenkins:2.277.4-alpine"
       tag: "jenkinsfile-runner-base-local"
       build: true
 
@@ -29,7 +29,7 @@ war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.291"
+    version: "2.277.4"
 
 systemProperties:
     jenkins.model.Jenkins.slaveAgentPort: "50000"
@@ -227,11 +227,11 @@ plugins:
     artifactId: "github-api"
     source:
       version: "1.123"
-# GitHub Branch Source (Jenkins-Version: 2.283)
+# GitHub Branch Source (Jenkins-Version: 2.271)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "github-branch-source"
     source:
-      version: "2.10.3"
+      version: "2.10.2"
 # Gradle (Jenkins-Version: 2.138.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "gradle"
@@ -442,11 +442,11 @@ plugins:
     artifactId: "snakeyaml-api"
     source:
       version: "1.27.0"
-# SSH Credentials (Jenkins-Version: 2.282)
+# SSH Credentials (Jenkins-Version: 2.190.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "ssh-credentials"
     source:
-      version: "1.18.2"
+      version: "1.18.1"
 # Structs (Jenkins-Version: 2.222.4)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "structs"

--- a/jenkinsfile-runner-base-image/packager-config.yml
+++ b/jenkinsfile-runner-base-image/packager-config.yml
@@ -19,7 +19,7 @@ buildSettings:
         # git: https://github.com/jenkinsci/jenkinsfile-runner.git
         # branch: "1.0-beta-19"
         git: https://github.com/SAP/stewardci-jenkinsfilerunner-image
-        branch: "jenkinsfile-runner--1.0-beta-19-steward-1"
+        branch: "jenkinsfile-runner--1.0-beta-27-steward-1"
     docker:
       base: "jenkins/jenkins:2.277.4-alpine"
       tag: "jenkinsfile-runner-base-local"

--- a/jenkinsfile-runner-base-image/plugins.txt
+++ b/jenkinsfile-runner-base-image/plugins.txt
@@ -1,4 +1,3 @@
-analysis-collector
 badge
 build-timeout
 cobertura

--- a/jenkinsfile-runner-base-image/plugins.txt
+++ b/jenkinsfile-runner-base-image/plugins.txt
@@ -1,4 +1,3 @@
-badge
 build-timeout
 cobertura
 configuration-as-code
@@ -6,7 +5,6 @@ configuration-as-code-groovy
 credentials
 credentials-binding
 cucumber-testresult-plugin
-email-ext
 gatling
 git
 github

--- a/update/generate.groovy
+++ b/update/generate.groovy
@@ -1,6 +1,10 @@
 import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
 
+// updateCenterUrl needs to be in sync with changelogUrl in updateJenkins.sh!
+updateCenterUrl = "https://updates.jenkins.io/stable/update-center.json".toURL()    //LTS
+//updateCenterUrl = "https://updates.jenkins.io/current/update-center.json".toURL() //LATEST
+
 wantedPlugins = [:]
 resultingPlugins = [:]
 updateCenter = null
@@ -32,8 +36,7 @@ def process(wantedPluginsFile, outFormat, skipOptional) {
         wantedPluginNames << line
     }
 
-    def url = "https://updates.jenkins.io/update-center.json".toURL()
-    def updateCenterJson = url.text
+    def updateCenterJson = updateCenterUrl.text
     updateCenterJson = updateCenterJson.substring(0, updateCenterJson.length()-2)
     updateCenterJson = updateCenterJson.replace("updateCenter.post(", "")
     updateCenterJson = updateCenterJson.trim()

--- a/update/generate.groovy
+++ b/update/generate.groovy
@@ -43,6 +43,7 @@ def process(wantedPluginsFile, outFormat, skipOptional) {
 
     for(wanted in wantedPluginNames){
         def wantedPlugin = updateCenter.plugins[wanted]
+        if(wantedPlugin == null) throw new RuntimeException("Plugin '${wanted}' not in update-center.json!")
         wantedPlugins[wantedPlugin.name] = wantedPlugin
         resultingPlugins[wantedPlugin.name] = wantedPlugin
         if(verbose) System.err.println "Added: " + wantedPlugin.name

--- a/update/updateJenkins.sh
+++ b/update/updateJenkins.sh
@@ -13,21 +13,23 @@ packagerConfig="${PROJECT_ROOT}/jenkinsfile-runner-base-image/packager-config.ym
 function main() {
     echo "This is not automated yet - update packager-config.yml manually!"
 
-    printLatestLTSVersion
+    printLatestVersion true
     printCurrentBase
 }
 
-function printLatestLTSVersion() {
+function printLatestVersion() {
+    #local url='https://www.jenkins.io/changelog-stable/' #LTS
+    local url='https://www.jenkins.io/changelog/'
     local s
-    s=$(curl -sL 'https://www.jenkins.io/changelog-stable/') || {
-        echo >&2 "failed to download Jenkins LTS changelog"
+    s=$(curl -sL "$url") || {
+        echo >&2 "failed to download Jenkins changelog from $url"
         exit 1
     }
     s=$(<<<"$s" grep "^What's new in" -m1) || {
-        echo >&2 "failed to extract version from Jenkins LTS changelog"
+        echo >&2 "failed to extract version from Jenkins changelog ($url)"
         exit 1
     }
-    <<<"$s" sed -e 's/.*in /Latest LTS: /g'
+    <<<"$s" sed -e 's/.*in /Latest: /g'
 }
 
 function printCurrentBase() {

--- a/update/updateJenkins.sh
+++ b/update/updateJenkins.sh
@@ -2,6 +2,10 @@
 set -eu -o pipefail
 exec <&-
 
+#changelogUrl needs to be in sync with updateCenterUrl in generate.groovy!
+changelogUrl='https://www.jenkins.io/changelog-stable/' #LTS
+#changelogUrl='https://www.jenkins.io/changelog/'       #LATEST
+
 PROJECT_ROOT=$(cd "$(dirname "$BASH_SOURCE")/.." && pwd) || {
     echo >&2 "failed to determine script location"
     exit 1
@@ -18,15 +22,13 @@ function main() {
 }
 
 function printLatestVersion() {
-    #local url='https://www.jenkins.io/changelog-stable/' #LTS
-    local url='https://www.jenkins.io/changelog/'
     local s
-    s=$(curl -sL "$url") || {
-        echo >&2 "failed to download Jenkins changelog from $url"
+    s=$(curl -sL "$changelogUrl") || {
+        echo >&2 "failed to download Jenkins changelog from $changelogUrl"
         exit 1
     }
     s=$(<<<"$s" grep "^What's new in" -m1) || {
-        echo >&2 "failed to extract version from Jenkins changelog ($url)"
+        echo >&2 "failed to extract version from Jenkins changelog ($changelogUrl)"
         exit 1
     }
     <<<"$s" sed -e 's/.*in /Latest: /g'


### PR DESCRIPTION
This PR is blocked, because some of our pipelines still require the `analysis-collector` plugin.
`analysis-collector` has been removed from the Jenkins Update site as it has been deprecated for a longer time. We should not try to "get it working" with the old plugin dependencies and update other plugins. I'm also not sure if a new Jenkins version (without plugin updates) would work.