### PR TITLE
workaround for #62

### DIFF
--- a/jenkinsfile-runner-steward-image/scripts/run.sh
+++ b/jenkinsfile-runner-steward-image/scripts/run.sh
@@ -65,6 +65,15 @@ function main() {
 
   export JAVA_OPTS="${JAVA_OPTS:+$JAVA_OPTS }-Dhudson.TcpSlaveAgentListener.hostName=$host_addr"
 
+  # Temporary workaround for https://github.com/SAP/stewardci-jenkinsfilerunner-image/issues/62
+  # Should be removed once the issue is fixed
+  (
+    ___LOCAL_BUILD_LOG_FILE_PATH="${_JENKINS_HOME}/jobs/${JOB_NAME:-job}/builds/${RUN_NUMBER:-1}/log"
+    mkdir -p "$(dirname "$___LOCAL_BUILD_LOG_FILE_PATH")"
+    touch "$___LOCAL_BUILD_LOG_FILE_PATH"
+  )
+  # End of workaround
+  
   local jfr_cmd=(
     /app/bin/jenkinsfile-runner
       -w "$_JENKINS_APP_DIR"


### PR DESCRIPTION
Create the local build log file _before_ starting JFR, so that JFR's log copy does not fail.

Should be reverted once a permanent fix for https://github.com/SAP/stewardci-jenkinsfilerunner-image/issues/62
has been established.