### PR TITLE
Workaround for #62 (attempt 2)

### DIFF
--- a/jenkinsfile-runner-base-image/packager-config.yml
+++ b/jenkinsfile-runner-base-image/packager-config.yml
@@ -15,8 +15,11 @@ buildSettings:
         #TODO: replace once Jenkinsfile Runner archives runner & CWP is updated
         noCache: true
       source:
-        git: https://github.com/jenkinsci/jenkinsfile-runner.git
-        branch: "1.0-beta-19"
+        # Use fork until fixes are available in upstream
+        # git: https://github.com/jenkinsci/jenkinsfile-runner.git
+        # branch: "1.0-beta-19"
+        git: https://github.com/SAP/stewardci-jenkinsfilerunner-image
+        branch: "jenkinsfile-runner--1.0-beta-19-steward-1"
     docker:
       base: "jenkins/jenkins:2.249.2-alpine"
       tag: "jenkinsfile-runner-base-local"


### PR DESCRIPTION
Use a fork of [jenkinsfile-runner](https://github.com/jenkinsci/jenkinsfile-runner) that contains a patch working around #62.

The fork is located in this repository in branches and tags starting with `jenkinsfile-runner--`.