### PR TITLE
Explicitly list disabled agent protocols

### DIFF
--- a/jenkinsfile-runner-base-image/casc.yml
+++ b/jenkinsfile-runner-base-image/casc.yml
@@ -5,11 +5,11 @@ jenkins:
   - "JNLP4-connect"
   - "Ping"
   disabledAgentProtocols:
-  - CLI-connect
-  - CLI2-connect
-  - JNLP-connect
-  - JNLP2-connect
-  - JNLP3-connect
+  - "CLI-connect"
+  - "CLI2-connect"
+  - "JNLP-connect"
+  - "JNLP2-connect"
+  - "JNLP3-connect"
   clouds:
   - kubernetes:
       containerCapStr: "0"

--- a/jenkinsfile-runner-base-image/casc.yml
+++ b/jenkinsfile-runner-base-image/casc.yml
@@ -4,6 +4,12 @@ jenkins:
   agentProtocols:
   - "JNLP4-connect"
   - "Ping"
+  disabledAgentProtocols:
+  - CLI-connect
+  - CLI2-connect
+  - JNLP-connect
+  - JNLP2-connect
+  - JNLP3-connect
   clouds:
   - kubernetes:
       containerCapStr: "0"


### PR DESCRIPTION
Recently we configured `agentProtocols`. In this PR we explicitly list `disabledAgentProtocols`.