### PR TITLE
Introduce Steward interface for container entrypoint

### DIFF
--- a/jenkinsfile-runner-steward-image/Dockerfile
+++ b/jenkinsfile-runner-steward-image/Dockerfile
@@ -19,6 +19,6 @@ USER jenkins:jenkins
 COPY --from=packager-output --chown=jenkins:jenkins /app /app
 COPY --from=packager-output --chown=jenkins:jenkins /usr/share/jenkins /usr/share/jenkins
 
-
 COPY scripts/ /scripts
-ENTRYPOINT [ "bash", "/scripts/run.sh" ]
+COPY steward-interface/ /steward-interface
+ENTRYPOINT [ "/steward-interface/entrypoint" ]

--- a/jenkinsfile-runner-steward-image/steward-interface/entrypoint
+++ b/jenkinsfile-runner-steward-image/steward-interface/entrypoint
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /scripts/run.sh "$@"


### PR DESCRIPTION
Steward creates Jenkinsfile Runner pods via Tekton task runs. To work
around a problem with container registry rate limits, Steward must
specify the JFR container entry point explicitly in the container spec
so that Tekton does not need to download the image manifest.

With this change a stable container entrypoint is defined and
established (`/steward-interface/entrypoint`), which can be implemented
by the image as desired.