### PR TITLE
improve exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,3 @@ Please create issues on this repository to contact us.
 ## To-Do (upcoming changes)
 
 see GitHub issues for planned changes
-

--- a/jenkinsfile-runner-base-image/build.sh
+++ b/jenkinsfile-runner-base-image/build.sh
@@ -12,8 +12,8 @@ function die() {
 
 cd "$(dirname "$BASH_SOURCE")" || die
 
-curl -O https://repo.jenkins-ci.org/releases/io/jenkins/tools/custom-war-packager/custom-war-packager-cli/1.7/custom-war-packager-cli-1.7-jar-with-dependencies.jar
-CUSTOM_WAR_PACKAGER_CLI_JAR="${PWD}/custom-war-packager-cli-1.7-jar-with-dependencies.jar"
+curl -L -o custom-war-packager-cli-1.7.jar https://repo.jenkins-ci.org/releases/io/jenkins/tools/custom-war-packager/custom-war-packager-cli/1.7/custom-war-packager-cli-1.7-jar-with-dependencies.jar
+CUSTOM_WAR_PACKAGER_CLI_JAR="${PWD}/custom-war-packager-cli-1.7.jar"
 
 echo "Building jenkinsfile-runner-base image"
-java -jar "$CUSTOM_WAR_PACKAGER_CLI_JAR" -configPath "packager-config.yml" || die
+java -jar "$CUSTOM_WAR_PACKAGER_CLI_JAR" -configPath "packager-config.yml" || die "Custom War Packager build failed"

--- a/jenkinsfile-runner-base-image/build.sh
+++ b/jenkinsfile-runner-base-image/build.sh
@@ -12,8 +12,8 @@ function die() {
 
 cd "$(dirname "$BASH_SOURCE")" || die
 
-curl -L -o custom-war-packager-cli-1.7.jar https://repo.jenkins-ci.org/releases/io/jenkins/tools/custom-war-packager/custom-war-packager-cli/1.7/custom-war-packager-cli-1.7-jar-with-dependencies.jar
 CUSTOM_WAR_PACKAGER_CLI_JAR="${PWD}/custom-war-packager-cli-1.7.jar"
+curl -L -o "$CUSTOM_WAR_PACKAGER_CLI_JAR" https://repo.jenkins-ci.org/releases/io/jenkins/tools/custom-war-packager/custom-war-packager-cli/1.7/custom-war-packager-cli-1.7-jar-with-dependencies.jar
 
 echo "Building jenkinsfile-runner-base image"
-java -jar "$CUSTOM_WAR_PACKAGER_CLI_JAR" -configPath "packager-config.yml" || die "Custom War Packager build failed"
+java -jar "$CUSTOM_WAR_PACKAGER_CLI_JAR" -configPath "packager-config.yml" || die "Custom WAR Packager failed"

--- a/jenkinsfile-runner-steward-image/scripts/run.sh
+++ b/jenkinsfile-runner-steward-image/scripts/run.sh
@@ -121,7 +121,7 @@ function main() {
       echo >&2 "error: could not log failed command to termination log"
     }
     rm -f "$jfr_err_log" &> /dev/null || true
-    terminate ${RESULT_ERROR_INFRA}
+    terminate $RESULT_ERROR_INFRA
   fi
   rm -f "$jfr_err_log" &> /dev/null || true
 

--- a/jenkinsfile-runner-steward-image/scripts/run.sh
+++ b/jenkinsfile-runner-steward-image/scripts/run.sh
@@ -1,18 +1,13 @@
 #!/bin/bash
 set -eu -o pipefail
 
+# Exit codes
 declare -r RESULT_SUCCESS=0
 declare -r RESULT_ERROR_INFRA=1
 declare -r RESULT_ERROR_CONTENT=2
 declare -r RESULT_ERROR_CONFIG=3
 
 unset FINAL_RESULT
-
-# terminate sets the passed RC and exits
-function terminate {
-  FINAL_RESULT=$1
-  exit
-}
 
 # on_exit will be called on each exit
 # if a valid RC is set by terminate function this RC is the final RC
@@ -27,6 +22,12 @@ function on_exit {
 }
 
 trap on_exit EXIT
+
+# terminate sets the passed RC and exits
+function terminate {
+  FINAL_RESULT=$1
+  exit
+}
 
 HERE=$(cd "$(dirname "$BASH_SOURCE")" && pwd) || {
   echo >&2 "error: failed to determine script location"


### PR DESCRIPTION
Improve the exit codes of the JFR.

Return codes
0 -> Pipeline run with result "SUCCESS"
1 -> Any other error occured
2 -> Pipeline completed with non "SUCCESS" result
3 -> Configuration error avoided start of the pipeline