### PR TITLE
[Fix] Downgrade kubernetes related plugins

### DIFF
--- a/jenkinsfile-runner-base-image/packager-config.yml
+++ b/jenkinsfile-runner-base-image/packager-config.yml
@@ -316,17 +316,17 @@ plugins:
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "kubernetes-client-api"
     source:
-      version: "6.3.1-206.v76d3b_6b_14db_b"
+      version: "5.12.2-193.v26a_6078f65a_9" # Do not change this version until Jenkins core version is updated to > 2.346.3.
 # Kubernetes Credentials (Jenkins-Version: 2.332.4)
   - groupId: "org.jenkinsci.plugins"
     artifactId: "kubernetes-credentials"
     source:
-      version: "0.10.0"
+      version: "0.9.0" # Do not change this version until Jenkins core version is updated to > 2.346.3.
 # Kubernetes Credentials Provider (Jenkins-Version: 2.303.3)
   - groupId: "com.cloudbees.jenkins.plugins"
     artifactId: "kubernetes-credentials-provider"
     source:
-      version: "1.209.v862c6e5fb_1ef"
+      version: "1.206.v7ce2cf7b_0c8b" # Do not change this version until Jenkins core version is updated to > 2.346.3.
 # Lockable Resources (Jenkins-Version: 2.289.3)
   - groupId: "org.6wind.jenkins"
     artifactId: "lockable-resources"

--- a/jenkinsfile-runner-steward-image/Dockerfile
+++ b/jenkinsfile-runner-steward-image/Dockerfile
@@ -1,6 +1,6 @@
 FROM jenkinsfile-runner-base-local as packager-output
-# eclipse-temurin:11.0.16.1_1-jdk-alpine
-FROM eclipse-temurin@sha256:6295fa4981cc24ed0b58a31a2b8a87b66e485eae27a66059bb6288a8a1f4e001
+# eclipse-temurin:11.0.18_10-jdk-alpine
+FROM eclipse-temurin@sha256:8368526729a4fa4275807761f51770c505a16c8dcad969609d7644de9dab9367
 
 RUN apk update && apk upgrade && \
     apk add jq xmlstarlet bash git curl


### PR DESCRIPTION
This change will fix issue #99. All kubernetes plugins used in Jenkins core version 2.346.3 cannot have a dependency to kubernetes-client-api-plugin version >= 6.* due to compatibility issues.

Unfortunately, the backwards incompatible plugin version are present in the 2.346.x update center and have to be adapted manually.

Fixes #99 