### PR TITLE
Workaround plugin config error

### DIFF
--- a/jenkinsfile-runner-steward-image/scripts/elasticsearch-log-config.jq
+++ b/jenkinsfile-runner-steward-image/scripts/elasticsearch-log-config.jq
@@ -118,6 +118,9 @@ if $leadingParam == "PIPELINE_LOG_FLUENTD_HOST" then
     "unclassified": {
       "elasticSearchLogs": {
         "elasticSearch": {
+          # This is a workaround for a bug in the plugin configuration loading.
+          # Once the bug is fixed, it can be removed.
+          "url": "https://dummy.value.to.pass.validation",
           "elasticsearchWriteAccess": {
             "fluentd": {
               "host": mandatory_param("PIPELINE_LOG_FLUENTD_HOST"),


### PR DESCRIPTION
At the moment, a bug in elasticsearch-log-plugin fails configuration loading if no elastic search url is configured.
To circumvent this, we set a dummy value.