### PR TITLE
Update ES logs-plugin version to 0.14.2

### DIFF
--- a/jenkinsfile-runner-base-image/packager-config.yml
+++ b/jenkinsfile-runner-base-image/packager-config.yml
@@ -56,7 +56,7 @@ plugins:
     artifactId: "pipeline-elasticsearch-logs"
     source:
       git: "https://github.com/SAP/elasticsearch-logs-plugin.git"
-      commit: "0.14.1"
+      commit: "0.14.2"
 
 
 # See plugins.txt for plugin selection without dependencies (keep this list in sync)


### PR DESCRIPTION
Run emitting steps of the fluency library in the ES-logs-plugin in a separate thread to let it not be interrupted by the Jenkins workflow.