### PR TITLE
Update to LTS 2.492.3 and update all plugins

### DIFF
--- a/jenkinsfile-runner-base-image/packager-config.yml
+++ b/jenkinsfile-runner-base-image/packager-config.yml
@@ -18,7 +18,7 @@ buildSettings:
         git: https://github.com/jenkinsci/jenkinsfile-runner
         branch: "1.0-beta-32"
     docker:
-      base: "jenkins/jenkins:2.462.3-alpine"
+      base: "jenkins/jenkins:2.492.3-alpine"
       tag: "jenkinsfile-runner-base-local"
       build: true
 
@@ -29,7 +29,7 @@ war:
     # In order to avoid severe backwards compatibility issues,
     # keep the Jenkins core version in sync with the used one
     # in the chosen jenkinsfile-runner release
-    version: "2.462.3"
+    version: "2.492.3"
 
 systemProperties:
     jenkins.model.Jenkins.slaveAgentPort: "50000"
@@ -62,71 +62,71 @@ plugins:
 # See README.md for options to generate the list below.
 
 ##PLUGINS-START (do not remove!)
-# Analysis Model API (Jenkins-Version: 2.462.1)
+# Analysis Model API (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "analysis-model-api"
     source:
-      version: "12.9.0"
-# OWASP Markup Formatter (Jenkins-Version: 2.387.3)
+      version: "13.2.0"
+# OWASP Markup Formatter (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "antisamy-markup-formatter"
     source:
-      version: "162.v0e6ec0fcfcf6"
-# Apache HttpComponents Client 4.x API (Jenkins-Version: 2.387.3)
+      version: "173.v680e3a_b_69ff3"
+# Apache HttpComponents Client 4.x API (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "apache-httpcomponents-client-4-api"
     source:
-      version: "4.5.14-208.v438351942757"
-# Apache HttpComponents Client 5.x API (Jenkins-Version: 2.361.4)
+      version: "4.5.14-269.vfa_2321039a_83"
+# Apache HttpComponents Client 5.x API (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "apache-httpcomponents-client-5-api"
     source:
-      version: "5.4-118.v199115451c4d"
-# ASM API (Jenkins-Version: 2.440.3)
+      version: "5.4.3-140.v2516ccde99e7"
+# ASM API (Jenkins-Version: 2.479.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "asm-api"
     source:
-      version: "9.7.1-95.v9f552033802a_"
-# Authentication Tokens API (Jenkins-Version: 2.387.3)
+      version: "9.8-135.vb_2239d08ee90"
+# Authentication Tokens API (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "authentication-tokens"
     source:
-      version: "1.119.v50285141b_7e1"
-# Bootstrap 5 API (Jenkins-Version: 2.426.3)
+      version: "1.131.v7199556c3004"
+# Bootstrap 5 API (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "bootstrap5-api"
     source:
-      version: "5.3.3-1"
-# bouncycastle API (Jenkins-Version: 2.361.4)
+      version: "5.3.3-2"
+# bouncycastle API (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "bouncycastle-api"
     source:
-      version: "2.30.1.78.1-248.ve27176eb_46cb_"
-# Branch API (Jenkins-Version: 2.426.3)
+      version: "2.30.1.80-256.vf98926042a_9b_"
+# Branch API (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "branch-api"
     source:
-      version: "2.1178.v969d9eb_c728e"
-# Build Timeout (Jenkins-Version: 2.440.3)
+      version: "2.1217.v43d8b_b_d8b_2c7"
+# Build Timeout (Jenkins-Version: 2.479.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "build-timeout"
     source:
-      version: "1.33"
-# Caffeine API (Jenkins-Version: 2.361.4)
+      version: "1.38"
+# Caffeine API (Jenkins-Version: 2.479.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "caffeine-api"
     source:
-      version: "3.1.8-133.v17b_1ff2e0599"
-# Checks API (Jenkins-Version: 2.426.3)
+      version: "3.2.0-166.v72a_6d74b_870f"
+# Checks API (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "checks-api"
     source:
-      version: "2.2.1"
-# Folders (Jenkins-Version: 2.462.1)
+      version: "367.v18b_7f530e54a_"
+# Folders (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "cloudbees-folder"
     source:
-      version: "6.955.v81e2a_35c08d3"
+      version: "6.1012.v79a_86a_1ea_c1f"
 # Cobertura (Jenkins-Version: 2.204.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "cobertura"
@@ -137,439 +137,444 @@ plugins:
     artifactId: "code-coverage-api"
     source:
       version: "4.99.0"
-# Commons Compress API (Jenkins-Version: 2.361.4)
+# Commons Compress API (Jenkins-Version: 2.489)
   - groupId: "io.jenkins.plugins"
     artifactId: "commons-compress-api"
     source:
-      version: "1.26.1-2"
-# commons-lang3 v3.x Jenkins API (Jenkins-Version: 2.361.4)
+      version: "1.27.1-3"
+# commons-lang3 v3.x Jenkins API (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "commons-lang3-api"
     source:
-      version: "3.17.0-84.vb_b_938040b_078"
-# commons-text API (Jenkins-Version: 2.440.3)
+      version: "3.17.0-87.v5cf526e63b_8b_"
+# commons-text API (Jenkins-Version: 2.479.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "commons-text-api"
     source:
-      version: "1.12.0-129.v99a_50df237f7"
-# Configuration as Code (Jenkins-Version: 2.440.3)
+      version: "1.13.0-153.v91dcd89e2a_22"
+# Configuration as Code (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins"
     artifactId: "configuration-as-code"
     source:
-      version: "1850.va_a_8c31d3158b_"
+      version: "1953.v148f87d74b_1e"
 # Configuration as Code Plugin - Groovy Scripting Extension (Jenkins-Version: 2.60.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "configuration-as-code-groovy"
     source:
       version: "1.1"
-# Coverage (Jenkins-Version: 2.426.3)
+# Coverage (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "coverage"
     source:
-      version: "1.16.1"
-# Credentials (Jenkins-Version: 2.462.3)
+      version: "2.4.0"
+# Credentials (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "credentials"
     source:
-      version: "1384.vf0a_2ed06f9c6"
-# Credentials Binding (Jenkins-Version: 2.414.3)
+      version: "1413.va_51c53703df1"
+# Credentials Binding (Jenkins-Version: 2.479)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "credentials-binding"
     source:
-      version: "681.vf91669a_32e45"
+      version: "687.v619cb_15e923f"
 # Cucumber json test reporting (Jenkins-Version: 1.651)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "cucumber-testresult-plugin"
     source:
       version: "0.10.1"
-# DataTables.net API (Jenkins-Version: 2.426.3)
+# DataTables.net API (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "data-tables-api"
     source:
-      version: "2.1.8-1"
-# Display URL API (Jenkins-Version: 2.361.1)
+      version: "2.2.2-1"
+# Display URL API (Jenkins-Version: 2.479)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "display-url-api"
     source:
-      version: "2.204.vf6fddd8a_8b_e9"
-# Durable Task (Jenkins-Version: 2.440.3)
+      version: "2.209.v582ed814ff2f"
+# Durable Task (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "durable-task"
     source:
-      version: "577.v2a_8a_4b_7c0247"
-# ECharts API (Jenkins-Version: 2.426.3)
+      version: "587.v84b_877235b_45"
+# ECharts API (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "echarts-api"
     source:
-      version: "5.5.1-1"
-# Font Awesome API (Jenkins-Version: 2.426.3)
+      version: "5.6.0-3"
+# Font Awesome API (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "font-awesome-api"
     source:
-      version: "6.6.0-2"
-# Forensics API (Jenkins-Version: 2.426.3)
+      version: "6.7.2-1"
+# Forensics API (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "forensics-api"
     source:
-      version: "2.6.0"
+      version: "3.1.0"
 # Gatling (Jenkins-Version: 2.150.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "gatling"
     source:
       version: "1.3.0"
-# Git (Jenkins-Version: 2.440.3)
+# Git (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "git"
     source:
-      version: "5.5.2"
-# Git client (Jenkins-Version: 2.440.3)
+      version: "5.7.0"
+# Git client (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "git-client"
     source:
-      version: "5.0.0"
-# GitHub (Jenkins-Version: 2.414.3)
+      version: "6.1.3"
+# GitHub (Jenkins-Version: 2.479.3)
   - groupId: "com.coravy.hudson.plugins.github"
     artifactId: "github"
     source:
-      version: "1.40.0"
-# GitHub API (Jenkins-Version: 2.361.4)
+      version: "1.43.0"
+# GitHub API (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "github-api"
     source:
-      version: "1.321-468.v6a_9f5f2d5a_7e"
-# GitHub Branch Source (Jenkins-Version: 2.440.3)
+      version: "1.321-488.v9b_c0da_9533f8"
+# GitHub Branch Source (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "github-branch-source"
     source:
-      version: "1797.v86fdb_4d57d43"
-# Gradle (Jenkins-Version: 2.401.3)
+      version: "1815.v9152b_2ff7a_1b_"
+# Gradle (Jenkins-Version: 2.440.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "gradle"
     source:
-      version: "2.13.1"
-# Gson API (Jenkins-Version: 2.426.3)
+      version: "2.14.1"
+# Gson API (Jenkins-Version: 2.479.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "gson-api"
     source:
-      version: "2.11.0-41.v019fcf6125dc"
-# HTML Publisher (Jenkins-Version: 2.387.3)
+      version: "2.13.0-133.v5a_e3236a_8251"
+# HTML Publisher (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "htmlpublisher"
     source:
-      version: "1.36"
-# HTTP Request (Jenkins-Version: 2.426.3)
+      version: "425"
+# HTTP Request (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "http_request"
     source:
-      version: "1.19"
-# InfluxDB (Jenkins-Version: 2.387.3)
+      version: "1.20"
+# InfluxDB (Jenkins-Version: 2.462.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "influxdb"
     source:
-      version: "3.6.1"
-# Instance Identity (Jenkins-Version: 2.361.4)
+      version: "4.0"
+# Instance Identity (Jenkins-Version: 2.479.3)
   - groupId: "org.jenkins-ci.modules"
     artifactId: "instance-identity"
     source:
-      version: "201.vd2a_b_5a_468a_a_6"
-# Ionicons API (Jenkins-Version: 2.361.4)
+      version: "203.v15e81a_1b_7a_38"
+# Ionicons API (Jenkins-Version: 2.479.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "ionicons-api"
     source:
-      version: "74.v93d5eb_813d5f"
-# Jackson 2 API (Jenkins-Version: 2.401.3)
+      version: "82.v0597178874e1"
+# Jackson 2 API (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "jackson2-api"
     source:
-      version: "2.17.0-379.v02de8ec9f64c"
+      version: "2.18.3-402.v74c4eb_f122b_2"
 # JaCoCo (Jenkins-Version: 2.426.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "jacoco"
     source:
-      version: "3.3.6"
-# Jakarta Activation API (Jenkins-Version: 2.361.4)
+      version: "3.3.7"
+# Jakarta Activation API (Jenkins-Version: 2.479.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "jakarta-activation-api"
     source:
-      version: "2.1.3-1"
-# Jakarta Mail API (Jenkins-Version: 2.361.4)
+      version: "2.1.3-2"
+# Jakarta Mail API (Jenkins-Version: 2.479.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "jakarta-mail-api"
     source:
-      version: "2.1.3-1"
-# JavaBeans Activation Framework (JAF) API (Jenkins-Version: 2.361.4)
+      version: "2.1.3-2"
+# JavaBeans Activation Framework (JAF) API (Jenkins-Version: 2.479.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "javax-activation-api"
     source:
-      version: "1.2.0-7"
-# JAXB (Jenkins-Version: 2.387.3)
+      version: "1.2.0-8"
+# JAXB (Jenkins-Version: 2.479.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "jaxb"
     source:
-      version: "2.3.9-1"
-# Java JSON Web Token (JJWT) (Jenkins-Version: 2.361.4)
+      version: "2.3.9-133.vb_ec76a_73f706"
+# Java JSON Web Token (JJWT) (Jenkins-Version: 2.479.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "jjwt-api"
     source:
-      version: "0.11.5-112.ve82dfb_224b_a_d"
-# Joda Time API (Jenkins-Version: 2.440.3)
+      version: "0.11.5-120.v0268cf544b_89"
+# Joda Time API (Jenkins-Version: 2.479.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "joda-time-api"
     source:
-      version: "2.13.0-85.vb_64d1c2921f1"
-# JQuery3 API (Jenkins-Version: 2.426.3)
+      version: "2.14.0-127.v7d9da_295a_d51"
+# JQuery3 API (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "jquery3-api"
     source:
-      version: "3.7.1-2"
-# JSON Api (Jenkins-Version: 2.414.3)
+      version: "3.7.1-3"
+# JSON Api (Jenkins-Version: 2.479.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "json-api"
     source:
-      version: "20240303-41.v94e11e6de726"
-# JSON Path API (Jenkins-Version: 2.426.3)
+      version: "20250107-125.v28b_a_ffa_eb_f01"
+# JSON Path API (Jenkins-Version: 2.479.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "json-path-api"
     source:
-      version: "2.9.0-58.v62e3e85b_a_655"
-# JUnit (Jenkins-Version: 2.414.3)
+      version: "2.9.0-148.v22a_7ffe323ce"
+# jsoup API (Jenkins-Version: 2.479.3)
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "jsoup"
+    source:
+      version: "1.19.1-38.v216a_f3721b_3c"
+# JUnit (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "junit"
     source:
-      version: "1304.vc85a_b_ca_96613"
-# Kubernetes (Jenkins-Version: 2.426.3)
+      version: "1322.v1556dc1c59a_f"
+# Kubernetes (Jenkins-Version: 2.479.3)
   - groupId: "org.csanchez.jenkins.plugins"
     artifactId: "kubernetes"
     source:
-      version: "4290.v93ea_4b_b_26a_61"
-# Kubernetes Client API (Jenkins-Version: 2.401.3)
+      version: "4324.vfec199a_33512"
+# Kubernetes Client API (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "kubernetes-client-api"
     source:
-      version: "6.10.0-240.v57880ce8b_0b_2"
-# Kubernetes Credentials (Jenkins-Version: 2.426.3)
+      version: "6.10.0-251.v556f5f100500"
+# Kubernetes Credentials (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkinsci.plugins"
     artifactId: "kubernetes-credentials"
     source:
-      version: "190.v03c305394deb_"
-# Kubernetes Credentials Provider (Jenkins-Version: 2.414.1)
+      version: "192.v4d5b_1c429d17"
+# Kubernetes Credentials Provider (Jenkins-Version: 2.479.1)
   - groupId: "com.cloudbees.jenkins.plugins"
     artifactId: "kubernetes-credentials-provider"
     source:
-      version: "1.262.v2670ef7ea_0c5"
-# Lockable Resources (Jenkins-Version: 2.440.3)
+      version: "1.276.v99a_de03cb_076"
+# Lockable Resources (Jenkins-Version: 2.479.1)
   - groupId: "org.6wind.jenkins"
     artifactId: "lockable-resources"
     source:
-      version: "1315.v4ea_8e5159ec8"
-# Mailer (Jenkins-Version: 2.440.3)
+      version: "1349.v8b_ccb_c5487f7"
+# Mailer (Jenkins-Version: 2.479)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "mailer"
     source:
-      version: "488.v0c9639c1a_eb_3"
-# Matrix Project (Jenkins-Version: 2.440.3)
+      version: "489.vd4b_25144138f"
+# Matrix Project (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "matrix-project"
     source:
-      version: "839.vff91cd7e3a_b_2"
-# Metrics (Jenkins-Version: 2.387.3)
+      version: "847.v88a_f90ff9f20"
+# Metrics (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "metrics"
     source:
-      version: "4.2.21-451.vd51df8df52ec"
-# Mina SSHD API :: Common (Jenkins-Version: 2.426.3)
+      version: "4.2.21-464.vc9fa_a_0d6265d"
+# Mina SSHD API :: Common (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins.plugins.mina-sshd-api"
     artifactId: "mina-sshd-api-common"
     source:
-      version: "2.14.0-133.vcc091215a_358"
-# Mina SSHD API :: Core (Jenkins-Version: 2.426.3)
+      version: "2.15.0-161.vb_200831a_c15b_"
+# Mina SSHD API :: Core (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins.plugins.mina-sshd-api"
     artifactId: "mina-sshd-api-core"
     source:
-      version: "2.14.0-133.vcc091215a_358"
-# OkHttp (Jenkins-Version: 2.387.3)
+      version: "2.15.0-161.vb_200831a_c15b_"
+# OkHttp (Jenkins-Version: 2.479.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "okhttp-api"
     source:
-      version: "4.11.0-172.vda_da_1feeb_c6e"
-# Pipeline: Build Step (Jenkins-Version: 2.387.3)
+      version: "4.11.0-189.v976fa_d3379d6"
+# Pipeline: Build Step (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "pipeline-build-step"
     source:
-      version: "540.vb_e8849e1a_b_d8"
-# Pipeline: GitHub (Jenkins-Version: 2.375.3)
+      version: "567.vea_ce550ece97"
+# Pipeline: GitHub (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "pipeline-github"
     source:
-      version: "2.8-159.09e4403bc62f"
-# Pipeline: GitHub Groovy Libraries (Jenkins-Version: 2.361.4)
+      version: "2.8-162.382498405fdc"
+# Pipeline: GitHub Groovy Libraries (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "pipeline-github-lib"
     source:
-      version: "61.v629f2cc41d83"
-# Pipeline: Groovy Libraries (Jenkins-Version: 2.414.3)
+      version: "65.v203688e7727e"
+# Pipeline: Groovy Libraries (Jenkins-Version: 2.479.1)
   - groupId: "io.jenkins.plugins"
     artifactId: "pipeline-groovy-lib"
     source:
-      version: "730.ve57b_34648c63"
-# Pipeline: Input Step (Jenkins-Version: 2.440)
+      version: "752.vdddedf804e72"
+# Pipeline: Input Step (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "pipeline-input-step"
     source:
-      version: "495.ve9c153f6067b_"
-# Pipeline: Milestone Step (Jenkins-Version: 2.361.4)
+      version: "517.vf8e782ee645c"
+# Pipeline: Milestone Step (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "pipeline-milestone-step"
     source:
-      version: "119.vdfdc43fc3b_9a_"
-# Pipeline: Model API (Jenkins-Version: 2.426.3)
+      version: "127.vb_52887ca_3b_6d"
+# Pipeline: Model API (Jenkins-Version: 2.479.3)
   - groupId: "org.jenkinsci.plugins"
     artifactId: "pipeline-model-api"
     source:
-      version: "2.2214.vb_b_34b_2ea_9b_83"
-# Pipeline: Declarative (Jenkins-Version: 2.426.3)
+      version: "2.2254.v2a_978de46f35"
+# Pipeline: Declarative (Jenkins-Version: 2.479.3)
   - groupId: "org.jenkinsci.plugins"
     artifactId: "pipeline-model-definition"
     source:
-      version: "2.2214.vb_b_34b_2ea_9b_83"
-# Pipeline: Declarative Extension Points API (Jenkins-Version: 2.426.3)
+      version: "2.2254.v2a_978de46f35"
+# Pipeline: Declarative Extension Points API (Jenkins-Version: 2.479.3)
   - groupId: "org.jenkinsci.plugins"
     artifactId: "pipeline-model-extensions"
     source:
-      version: "2.2214.vb_b_34b_2ea_9b_83"
-# Pipeline: Stage Step (Jenkins-Version: 2.361.4)
+      version: "2.2254.v2a_978de46f35"
+# Pipeline: Stage Step (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "pipeline-stage-step"
     source:
-      version: "312.v8cd10304c27a_"
-# Pipeline: Stage Tags Metadata (Jenkins-Version: 2.426.3)
+      version: "322.vecffa_99f371c"
+# Pipeline: Stage Tags Metadata (Jenkins-Version: 2.479.3)
   - groupId: "org.jenkinsci.plugins"
     artifactId: "pipeline-stage-tags-metadata"
     source:
-      version: "2.2214.vb_b_34b_2ea_9b_83"
-# Pipeline Utility Steps (Jenkins-Version: 2.414.3)
+      version: "2.2254.v2a_978de46f35"
+# Pipeline Utility Steps (Jenkins-Version: 2.492.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "pipeline-utility-steps"
     source:
-      version: "2.17.0"
-# Plain Credentials (Jenkins-Version: 2.426.3)
+      version: "2.19.0"
+# Plain Credentials (Jenkins-Version: 2.479.3)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "plain-credentials"
     source:
-      version: "183.va_de8f1dd5a_2b_"
-# Plugin Utilities API (Jenkins-Version: 2.462.1)
+      version: "195.vb_906e9073dee"
+# Plugin Utilities API (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "plugin-util-api"
     source:
-      version: "5.1.0"
-# Prism API (Jenkins-Version: 2.426.3)
+      version: "6.1.0"
+# Prism API (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "prism-api"
     source:
-      version: "1.29.0-17"
-# Resource Disposer (Jenkins-Version: 2.387.3)
+      version: "1.30.0-1"
+# Resource Disposer (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "resource-disposer"
     source:
-      version: "0.24"
-# SCM API (Jenkins-Version: 2.426.3)
+      version: "0.25"
+# SCM API (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "scm-api"
     source:
-      version: "696.v778d637b_a_762"
-# Script Security (Jenkins-Version: 2.387.3)
+      version: "704.v3ce5c542825a_"
+# Script Security (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "script-security"
     source:
-      version: "1362.v67dc1f0e1b_b_3"
-# SnakeYAML API (Jenkins-Version: 2.361.4)
+      version: "1373.vb_b_4a_a_c26fa_00"
+# SnakeYAML API (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "snakeyaml-api"
     source:
-      version: "2.3-123.v13484c65210a_"
-# SSH Credentials (Jenkins-Version: 2.426.3)
+      version: "2.3-125.v4d77857a_b_402"
+# SSH Credentials (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "ssh-credentials"
     source:
-      version: "343.v884f71d78167"
-# Structs (Jenkins-Version: 2.414.3)
+      version: "355.v9b_e5b_cde5003"
+# Structs (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "structs"
     source:
-      version: "338.v848422169819"
-# Timestamper (Jenkins-Version: 2.375.4)
+      version: "343.vdcf37b_a_c81d5"
+# Timestamper (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "timestamper"
     source:
-      version: "1.27"
-# Token Macro (Jenkins-Version: 2.401.3)
+      version: "1.28"
+# Token Macro (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "token-macro"
     source:
-      version: "400.v35420b_922dcb_"
-# Variant (Jenkins-Version: 2.361.4)
+      version: "444.v52de7e9c573d"
+# Variant (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "variant"
     source:
-      version: "60.v7290fc0eb_b_cd"
-# Warnings (Jenkins-Version: 2.462.1)
+      version: "70.va_d9f17f859e0"
+# Warnings (Jenkins-Version: 2.479.3)
   - groupId: "io.jenkins.plugins"
     artifactId: "warnings-ng"
     source:
-      version: "11.9.0"
-# Pipeline (Jenkins-Version: 2.361.4)
+      version: "12.5.0"
+# Pipeline (Jenkins-Version: 2.479.3)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-aggregator"
     source:
-      version: "600.vb_57cdd26fdd7"
-# Pipeline: API (Jenkins-Version: 2.440.3)
+      version: "608.v67378e9d3db_1"
+# Pipeline: API (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-api"
     source:
-      version: "1336.vee415d95c521"
-# Pipeline: Basic Steps (Jenkins-Version: 2.361.4)
+      version: "1371.ve334280b_d611"
+# Pipeline: Basic Steps (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-basic-steps"
     source:
-      version: "1058.vcb_fc1e3a_21a_9"
-# Pipeline: Groovy (Jenkins-Version: 2.426.3)
+      version: "1079.vce64b_a_929c5a_"
+# Pipeline: Groovy (Jenkins-Version: 2.479.3)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-cps"
     source:
-      version: "3969.vdc9d3a_efcc6a_"
-# Pipeline: Nodes and Processes (Jenkins-Version: 2.440.1)
+      version: "4080.va_15b_44a_91525"
+# Pipeline: Nodes and Processes (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-durable-task-step"
     source:
-      version: "1371.vb_7cec8f3b_95e"
-# Pipeline: Job (Jenkins-Version: 2.454)
+      version: "1405.v1fcd4a_d00096"
+# Pipeline: Job (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"
     source:
-      version: "1436.vfa_244484591f"
-# Pipeline: Multibranch (Jenkins-Version: 2.462)
+      version: "1508.v9cb_c3a_a_89dfd"
+# Pipeline: Multibranch (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-multibranch"
     source:
-      version: "795.ve0cb_1f45ca_9a_"
-# Pipeline: SCM Step (Jenkins-Version: 2.387.3)
+      version: "806.vb_b_688f609ee9"
+# Pipeline: SCM Step (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-scm-step"
     source:
-      version: "427.v4ca_6512e7df1"
-# Pipeline: Step API (Jenkins-Version: 2.414.3)
+      version: "437.v05a_f66b_e5ef8"
+# Pipeline: Step API (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-step-api"
     source:
-      version: "678.v3ee58b_469476"
-# Pipeline: Supporting APIs (Jenkins-Version: 2.440.3)
+      version: "700.v6e45cb_a_5a_a_21"
+# Pipeline: Supporting APIs (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-support"
     source:
-      version: "926.v9f4f9b_b_98c19"
-# Workspace Cleanup (Jenkins-Version: 2.440.3)
+      version: "968.v8f17397e87b_8"
+# Workspace Cleanup (Jenkins-Version: 2.479.1)
   - groupId: "org.jenkins-ci.plugins"
     artifactId: "ws-cleanup"
     source:
-      version: "0.47"
+      version: "0.48"
 ##PLUGINS-END (do not remove!)

--- a/jenkinsfile-runner-steward-image/Dockerfile
+++ b/jenkinsfile-runner-steward-image/Dockerfile
@@ -1,5 +1,5 @@
 FROM jenkinsfile-runner-base-local as packager-output
-FROM eclipse-temurin:11.0.24_8-jdk-alpine@sha256:c71e83ce79092bfef4a4638c62e51091717029e90b818b492b89afd8e948fd8a
+FROM eclipse-temurin:17.0.14_7-jdk-alpine-3.21@sha256:b16e661d76d3af0d226d0585063dbcafe7fb8a4ef31cfcaaec71d39c41269420
 
 RUN apk update && apk upgrade && \
     apk add jq xmlstarlet bash git curl

--- a/update/generate.groovy
+++ b/update/generate.groovy
@@ -3,7 +3,7 @@ import groovy.json.JsonOutput
 
 // updateCenterUrl needs to be in sync with changelogUrl in updateJenkins.sh!
 // updateCenterUrl = "https://updates.jenkins.io/stable/update-center.json".toURL()    //LTS
-updateCenterUrl = "https://updates.jenkins.io/update-center.json?version=2.462.3".toURL() // Version-specific
+updateCenterUrl = "https://updates.jenkins.io/update-center.json?version=2.492.3".toURL() // Version-specific
 //updateCenterUrl = "https://updates.jenkins.io/current/update-center.json".toURL() //LATEST
 
 wantedPlugins = [:]


### PR DESCRIPTION
This change also contains an update of the base image `eclipse-temurin` to version `17.0.14_7-jdk-alpine-3.21`.
From LTS Version `2.479.1` the Jenkins core switch to Java 17.